### PR TITLE
[NOREF] Fix start request links in workspace help cards

### DIFF
--- a/src/views/SystemWorkspace/components/HelpLinks/SystemCardGroup.tsx
+++ b/src/views/SystemWorkspace/components/HelpLinks/SystemCardGroup.tsx
@@ -9,9 +9,14 @@ import SystemHelpCard from './SystemHelpCard';
 type OperationalSolutionsHelpProps = {
   className?: string;
   cards: HelpLinkType[];
+  linkSearchQuery: string | undefined;
 };
 
-const HelpCardGroup = ({ className, cards }: OperationalSolutionsHelpProps) => {
+const HelpCardGroup = ({
+  className,
+  cards,
+  linkSearchQuery
+}: OperationalSolutionsHelpProps) => {
   return (
     <div
       className={classNames(
@@ -21,6 +26,15 @@ const HelpCardGroup = ({ className, cards }: OperationalSolutionsHelpProps) => {
     >
       <CardGroup className={className}>
         {cards.map(card => {
+          // Add the `linkSearchQuery` for a couple of starting request cards
+          let { link } = card;
+          if (
+            linkSearchQuery &&
+            (link === '/system/request-type' || link === '/trb/start')
+          ) {
+            link += `?${linkSearchQuery}`;
+          }
+
           return (
             <Grid
               tablet={{ col: 6 }}
@@ -30,7 +44,7 @@ const HelpCardGroup = ({ className, cards }: OperationalSolutionsHelpProps) => {
             >
               <SystemHelpCard
                 header={card.header}
-                link={card.link}
+                link={link}
                 linkText={card.linkText}
                 external={card.external}
               />

--- a/src/views/SystemWorkspace/components/HelpLinks/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemWorkspace/components/HelpLinks/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Help Links component > matches snapshot 1`] = `
             >
               <a
                 class="usa-link display-flex flex-align-center"
-                href="/system/request-type"
+                href="/system/request-type?linkCedarSystemId=1"
               >
                 Start an IT Governance request
                 <svg
@@ -80,7 +80,7 @@ exports[`Help Links component > matches snapshot 1`] = `
             >
               <a
                 class="usa-link display-flex flex-align-center"
-                href="/trb/start"
+                href="/trb/start?linkCedarSystemId=1"
               >
                 Start a technical assistance request
                 <svg

--- a/src/views/SystemWorkspace/components/HelpLinks/index.test.tsx
+++ b/src/views/SystemWorkspace/components/HelpLinks/index.test.tsx
@@ -18,7 +18,10 @@ describe('Help Links component', () => {
   it('matches snapshot', async () => {
     const { asFragment } = render(
       <MemoryRouter>
-        <HelpCardGroup cards={helpCards} />
+        <HelpCardGroup
+          cards={helpCards}
+          linkSearchQuery="linkCedarSystemId=1"
+        />
       </MemoryRouter>
     );
 

--- a/src/views/SystemWorkspace/components/HelpLinks/index.tsx
+++ b/src/views/SystemWorkspace/components/HelpLinks/index.tsx
@@ -8,7 +8,13 @@ import { HelpLinkType } from 'i18n/en-US/systemWorkspace';
 
 import HelpCardGroup from './SystemCardGroup';
 
-export const HelpLinks = ({ classname }: { classname?: string }) => {
+export const HelpLinks = ({
+  classname,
+  linkSearchQuery
+}: {
+  classname?: string;
+  linkSearchQuery: string | undefined;
+}) => {
   const { t } = useTranslation('systemWorkspace');
 
   const helpCards = t<HelpLinkType[]>('helpLinks.links', {
@@ -43,7 +49,7 @@ export const HelpLinks = ({ classname }: { classname?: string }) => {
         bold={false}
         className="text-normal margin-bottom-1"
       >
-        <HelpCardGroup cards={helpCards} />
+        <HelpCardGroup cards={helpCards} linkSearchQuery={linkSearchQuery} />
       </CollapsableLink>
     </SummaryBox>
   );

--- a/src/views/SystemWorkspace/components/RequestsCard/index.tsx
+++ b/src/views/SystemWorkspace/components/RequestsCard/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@trussworks/react-uswds';
 
 import UswdsReactLink from 'components/LinkWrapper';
-import linkCedarSystemIdQueryString from 'utils/linkCedarSystemIdQueryString';
 
 import SpacesCard from '../SpacesCard';
 
@@ -11,12 +10,16 @@ type RequestsCardProps = {
   systemId: string;
   trbCount: number;
   itgovCount: number;
+  linkSearchQuery: string | undefined;
 };
 
-function RequestsCard({ systemId, trbCount, itgovCount }: RequestsCardProps) {
+function RequestsCard({
+  systemId,
+  trbCount,
+  itgovCount,
+  linkSearchQuery
+}: RequestsCardProps) {
   const { t } = useTranslation('systemWorkspace');
-
-  const linkSearchQuery = linkCedarSystemIdQueryString(systemId);
 
   return (
     <SpacesCard

--- a/src/views/SystemWorkspace/index.tsx
+++ b/src/views/SystemWorkspace/index.tsx
@@ -17,6 +17,7 @@ import {
   GetSystemWorkspaceVariables
 } from 'queries/types/GetSystemWorkspace';
 import { RoleTypeName } from 'types/systemProfile';
+import linkCedarSystemIdQueryString from 'utils/linkCedarSystemIdQueryString';
 import NotFound from 'views/NotFound';
 import { getAtoStatus } from 'views/SystemProfile';
 import Breadcrumbs from 'views/TechnicalAssistance/Breadcrumbs';
@@ -54,6 +55,9 @@ export const SystemWorkspace = () => {
         role => role.roleTypeName === RoleTypeName.ISSO
       )
     : undefined;
+
+  /** The `linkSearchQuery` is used on starting new request links throughout workspace */
+  const linkSearchQuery = linkCedarSystemIdQueryString(systemId);
 
   if (loading) {
     return <PageLoading />;
@@ -111,7 +115,10 @@ export const SystemWorkspace = () => {
         />
       </div>
 
-      <HelpLinks classname="margin-top-3 margin-bottom-5" />
+      <HelpLinks
+        classname="margin-top-3 margin-bottom-5"
+        linkSearchQuery={linkSearchQuery}
+      />
 
       <h2>{t('spaces.header')}</h2>
 
@@ -142,6 +149,7 @@ export const SystemWorkspace = () => {
               systemId={systemId}
               trbCount={cedarSystem.linkedTrbRequests.length}
               itgovCount={cedarSystem.linkedSystemIntakes.length}
+              linkSearchQuery={linkSearchQuery}
             />
           )}
         </CardGroup>


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [EASI-1234] [EASI-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# NOREF

Adds missing `linkSearchQuery` to starting request links found in the first 2 help cards.