### PR TITLE
[NOREF] Fix status column sorting on requests tables

### DIFF
--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -128,14 +128,15 @@ const useRequestTableColumns = (
 
   const statusColumn: Column<SystemIntakeForTable> = {
     Header: t<string>('intake:fields.status'),
-    accessor: 'statusAdmin',
-    Cell: ({
-      row,
-      value
-    }: CellProps<SystemIntakeForTable, SystemIntakeForTable['statusAdmin']>) =>
-      t(`governanceReviewTeam:systemIntakeStatusAdmin.${value}`, {
-        lcid: row.original.lcid
-      })
+    id: 'statusAdmin',
+    accessor: obj => {
+      return t(
+        `governanceReviewTeam:systemIntakeStatusAdmin.${obj.statusAdmin}`,
+        {
+          lcid: obj.lcid
+        }
+      );
+    }
   };
 
   const lcidExpirationDateColumn: Column<SystemIntakeForTable> = {

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -102,16 +102,16 @@ const Table = ({
         Header: t('requestsTable.headers.status'),
         // The status property is just a generic property available on all request types
         // See cases below for details on how statuses are determined by type
-        accessor: 'status',
-        Cell: ({ row, value }: any) => {
-          switch (row.original.type) {
+        id: 'status',
+        accessor: (obj: any) => {
+          switch (obj.type) {
             case t(`requestsTable.types.GOVERNANCE_REQUEST`):
               return t(
-                `governanceReviewTeam:systemIntakeStatusRequester.${row.original.statusRequester}`,
-                { lcid: row.original.lcid }
+                `governanceReviewTeam:systemIntakeStatusRequester.${obj.statusRequester}`,
+                { lcid: obj.lcid }
               );
             case t(`requestsTable.types.TRB`):
-              return value;
+              return obj.status;
             default:
               return '';
           }


### PR DESCRIPTION
This fixes the status column on ITGOV tables so that it sorts alphabetically.

The table is found on the ITGOV admin home page and the IT Gov tab > My IT Gov requests table.