### PR TITLE
[NOREF] ParticipantsTable component for GRB Review tab

### DIFF
--- a/src/views/GovernanceReviewTeam/GRBReview/GRBReviewerForm/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/GRBReview/GRBReviewerForm/index.test.tsx
@@ -27,10 +27,9 @@ import {
 import { MockedQuery } from 'types/util';
 import MockUsers from 'utils/testing/MockUsers';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
+import IsGrbViewContext from 'views/GovernanceReviewTeam/IsGrbViewContext';
 
-import IsGrbViewContext from '../IsGrbViewContext';
-
-import GRBReview from '.';
+import GRBReview from '..';
 
 const mockUsers = new MockUsers();
 const user = mockUsers.findByCommonName('Jerry Seinfeld')!;

--- a/src/views/GovernanceReviewTeam/GRBReview/GRBReviewerForm/index.tsx
+++ b/src/views/GovernanceReviewTeam/GRBReview/GRBReviewerForm/index.tsx
@@ -33,9 +33,8 @@ import RequiredAsterisk from 'components/shared/RequiredAsterisk';
 import { grbReviewerRoles, grbReviewerVotingRoles } from 'constants/grbRoles';
 import useMessage from 'hooks/useMessage';
 import CreateGRBReviewerSchema from 'validations/grbReviewerSchema';
+import { ReviewerKey } from 'views/GovernanceReviewTeam/subNavItems';
 import Pager from 'views/TechnicalAssistance/RequestForm/Pager';
-
-import { ReviewerKey } from '../subNavItems';
 
 type GRBReviewerFormFields = {
   userAccount: {

--- a/src/views/GovernanceReviewTeam/GRBReview/ParticipantsTable.tsx
+++ b/src/views/GovernanceReviewTeam/GRBReview/ParticipantsTable.tsx
@@ -1,0 +1,248 @@
+import React, { useContext, useMemo } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Column, useSortBy, useTable } from 'react-table';
+import { Button, ButtonGroup, Table } from '@trussworks/react-uswds';
+import { SystemIntakeGRBReviewerFragment } from 'gql/gen/graphql';
+
+import UswdsReactLink from 'components/LinkWrapper';
+import { SystemIntakeState } from 'types/graphql-global-types';
+import {
+  currentTableSortDescription,
+  getColumnSortStatus,
+  getHeaderSortIcon
+} from 'utils/tableSort';
+import IsGrbViewContext from 'views/GovernanceReviewTeam/IsGrbViewContext';
+
+type ParticipantsTableProps = {
+  id: string;
+  state: SystemIntakeState;
+  grbReviewers: SystemIntakeGRBReviewerFragment[];
+  setReviewerToRemove: (reviewer: SystemIntakeGRBReviewerFragment) => void;
+};
+
+/**
+ * Participants table used in GRB Review tab
+ */
+const ParticipantsTable = ({
+  id,
+  state,
+  grbReviewers,
+  setReviewerToRemove
+}: ParticipantsTableProps) => {
+  const { t } = useTranslation('grbReview');
+  const history = useHistory();
+  const { pathname } = useLocation();
+
+  const isGrbView = useContext(IsGrbViewContext);
+
+  /** Columns for table */
+  const columns = useMemo<Column<SystemIntakeGRBReviewerFragment>[]>(() => {
+    /** Column with action buttons to display for GRT admins */
+    const actionColumn: Column<SystemIntakeGRBReviewerFragment> = {
+      Header: t<string>('participantsTable.actions'),
+      Cell: ({
+        row: { original: reviewer }
+      }: {
+        row: { original: SystemIntakeGRBReviewerFragment };
+      }) => {
+        return (
+          <ButtonGroup data-testid="grbReviewerActions">
+            <Button
+              type="button"
+              onClick={() => history.push(`${pathname}/edit`, reviewer)}
+              unstyled
+            >
+              {t('Edit')}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => setReviewerToRemove(reviewer)}
+              className="text-error"
+              unstyled
+            >
+              {t('Remove')}
+            </Button>
+          </ButtonGroup>
+        );
+      }
+    };
+
+    return [
+      {
+        Header: t<string>('participantsTable.name'),
+        id: 'commonName',
+        accessor: ({ userAccount }) => userAccount.commonName
+      },
+      {
+        Header: t<string>('participantsTable.votingRole'),
+        accessor: 'votingRole',
+        Cell: ({ value }) => t<string>(`votingRoles.${value}`)
+      },
+      {
+        Header: t<string>('participantsTable.grbRole'),
+        accessor: 'grbRole',
+        Cell: ({ value }) => t<string>(`reviewerRoles.${value}`)
+      },
+      // Only display action column if user is GRT admin
+      ...(isGrbView ? [] : [actionColumn])
+    ];
+  }, [t, isGrbView, setReviewerToRemove, history, pathname]);
+
+  const table = useTable(
+    {
+      columns,
+      data: grbReviewers,
+      autoResetSortBy: false,
+      autoResetPage: true,
+      initialState: {
+        sortBy: useMemo(() => [{ id: 'commonName', desc: false }], [])
+      }
+    },
+    useSortBy
+  );
+
+  const {
+    getTableBodyProps,
+    getTableProps,
+    headerGroups,
+    prepareRow,
+    rows
+  } = table;
+
+  return (
+    <>
+      <h2 className="margin-bottom-0">{t('participants')}</h2>
+
+      <p className="margin-top-05 line-height-body-5">
+        {t('participantsText')}
+      </p>
+
+      {isGrbView ? (
+        // GRB Reviewer documentation links
+        <div className="bg-base-lightest padding-2">
+          <h4 className="margin-top-0 margin-bottom-1">
+            {t('availableDocumentation')}
+          </h4>
+          <ButtonGroup>
+            <UswdsReactLink
+              to={`/governance-review-board/${id}/business-case`}
+              className="margin-right-3"
+            >
+              {t('viewBusinessCase')}
+            </UswdsReactLink>
+            <UswdsReactLink
+              to={`/governance-review-board/${id}/intake-request`}
+              className="margin-right-3"
+            >
+              {t('viewIntakeRequest')}
+            </UswdsReactLink>
+            <UswdsReactLink to={`/governance-review-board/${id}/documents`}>
+              {t('viewOtherDocuments')}
+            </UswdsReactLink>
+          </ButtonGroup>
+        </div>
+      ) : (
+        // Add GRB reviewer button
+        <div className="desktop:display-flex flex-align-center">
+          <Button
+            type="button"
+            onClick={() => history.push(`${pathname}/add`)}
+            disabled={state === SystemIntakeState.CLOSED}
+            outline={grbReviewers.length > 0}
+          >
+            {t(
+              grbReviewers.length > 0
+                ? 'addAnotherGrbReviewer'
+                : 'addGrbReviewer'
+            )}
+          </Button>
+
+          {state === SystemIntakeState.CLOSED && (
+            <p className="desktop:margin-y-0 desktop:margin-left-1">
+              <Trans
+                i18nKey="grbReview:closedRequest"
+                components={{
+                  a: (
+                    <UswdsReactLink
+                      to={`/governance-review-team/${id}/resolutions/re-open-request`}
+                    >
+                      re-open
+                    </UswdsReactLink>
+                  )
+                }}
+              />
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="margin-top-3">
+        <Table bordered={false} fullWidth scrollable {...getTableProps()}>
+          <thead>
+            {headerGroups.map(headerGroup => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column, index) => (
+                  <th
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    aria-sort={getColumnSortStatus(column)}
+                    scope="col"
+                    className="border-bottom-2px"
+                  >
+                    <Button
+                      type="button"
+                      unstyled
+                      className="width-full display-flex"
+                      {...column.getSortByToggleProps()}
+                    >
+                      <div className="flex-fill text-no-wrap">
+                        {column.render('Header')}
+                      </div>
+                      <div className="position-relative width-205 margin-left-05">
+                        {getHeaderSortIcon(column)}
+                      </div>
+                    </Button>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <tr
+                  {...row.getRowProps()}
+                  data-testid={`grbReviewer-${row.original.userAccount.username}`}
+                >
+                  {row.cells.map((cell, index) => {
+                    return (
+                      <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </Table>
+
+        {rows.length === 0 && (
+          <p className="text-italic margin-top-neg-1">
+            {t('participantsTable.noReviewers')}
+          </p>
+        )}
+
+        {rows.length > 0 && (
+          <p
+            className="usa-sr-only usa-table__announcement-region"
+            aria-live="polite"
+          >
+            {currentTableSortDescription(headerGroups[0])}
+          </p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ParticipantsTable;

--- a/src/views/GovernanceReviewTeam/GRBReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/GRBReview/index.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { Column, useSortBy, useTable } from 'react-table';
+import { useHistory, useParams } from 'react-router-dom';
 import {
   Button,
   ButtonGroup,
   ModalFooter,
-  ModalHeading,
-  Table
+  ModalHeading
 } from '@trussworks/react-uswds';
 import {
   GetSystemIntakeGRBReviewersDocument,
@@ -21,16 +19,11 @@ import PageHeading from 'components/PageHeading';
 import Alert from 'components/shared/Alert';
 import useMessage from 'hooks/useMessage';
 import { SystemIntakeState } from 'types/graphql-global-types';
-import {
-  currentTableSortDescription,
-  getColumnSortStatus,
-  getHeaderSortIcon
-} from 'utils/tableSort';
 
-import IsGrbViewContext from '../IsGrbViewContext';
 import { ReviewerKey } from '../subNavItems';
 
 import GRBReviewerForm from './GRBReviewerForm';
+import ParticipantsTable from './ParticipantsTable';
 
 type GRBReviewProps = {
   id: string;
@@ -40,7 +33,6 @@ type GRBReviewProps = {
 
 const GRBReview = ({ id, state, grbReviewers }: GRBReviewProps) => {
   const { t } = useTranslation('grbReview');
-  const { pathname } = useLocation();
   const history = useHistory();
 
   const { reviewerType, action } = useParams<{
@@ -56,8 +48,6 @@ const GRBReview = ({ id, state, grbReviewers }: GRBReviewProps) => {
   ] = useState<SystemIntakeGRBReviewerFragment | null>(null);
 
   const { showMessage } = useMessage();
-
-  const isGrbView = useContext(IsGrbViewContext);
 
   const [mutate] = useDeleteSystemIntakeGRBReviewerMutation({
     refetchQueries: [
@@ -95,112 +85,42 @@ const GRBReview = ({ id, state, grbReviewers }: GRBReviewProps) => {
     [history, isForm, id, mutate, reviewerType, showMessage, t]
   );
 
-  const columns = useMemo<Column<SystemIntakeGRBReviewerFragment>[]>(() => {
-    /** Column with action buttons to display for GRT admins */
-    const actionColumn: Column<SystemIntakeGRBReviewerFragment> = {
-      Header: t<string>('participantsTable.actions'),
-      Cell: ({
-        row: { original: reviewer }
-      }: {
-        row: { original: SystemIntakeGRBReviewerFragment };
-      }) => {
-        return (
-          <ButtonGroup data-testid="grbReviewerActions">
-            <Button
-              type="button"
-              onClick={() => history.push(`${pathname}/edit`, reviewer)}
-              unstyled
-            >
-              {t('Edit')}
-            </Button>
-            <Button
-              type="button"
-              onClick={() => setReviewerToRemove(reviewer)}
-              className="text-error"
-              unstyled
-            >
-              {t('Remove')}
-            </Button>
-          </ButtonGroup>
-        );
-      }
-    };
-
-    return [
-      {
-        Header: t<string>('participantsTable.name'),
-        id: 'commonName',
-        accessor: ({ userAccount }) => userAccount.commonName
-      },
-      {
-        Header: t<string>('participantsTable.votingRole'),
-        accessor: 'votingRole',
-        Cell: ({ value }) => t<string>(`votingRoles.${value}`)
-      },
-      {
-        Header: t<string>('participantsTable.grbRole'),
-        accessor: 'grbRole',
-        Cell: ({ value }) => t<string>(`reviewerRoles.${value}`)
-      },
-      // Only display action column if user is GRT admin
-      ...(isGrbView ? [] : [actionColumn])
-    ];
-  }, [t, isGrbView, setReviewerToRemove, history, pathname]);
-
-  const table = useTable(
-    {
-      columns,
-      data: grbReviewers,
-      autoResetSortBy: false,
-      autoResetPage: true,
-      initialState: {
-        sortBy: useMemo(() => [{ id: 'commonName', desc: false }], [])
-      }
-    },
-    useSortBy
-  );
-
-  const {
-    getTableBodyProps,
-    getTableProps,
-    headerGroups,
-    prepareRow,
-    rows
-  } = table;
-
   return (
     <>
-      {!!reviewerToRemove && (
-        <Modal
-          isOpen={!!reviewerToRemove}
-          closeModal={() => setReviewerToRemove(null)}
-        >
-          <ModalHeading>
-            {t('removeModal.title', {
-              commonName: reviewerToRemove.userAccount.commonName
-            })}
-          </ModalHeading>
-          <p>{t('removeModal.text')}</p>
-          <ModalFooter>
-            <ButtonGroup>
-              <Button
-                type="button"
-                onClick={() => removeGRBReviewer(reviewerToRemove)}
-                className="bg-error margin-right-1"
-              >
-                {t('removeModal.remove')}
-              </Button>
-              <Button
-                type="button"
-                onClick={() => setReviewerToRemove(null)}
-                unstyled
-              >
-                {t('Cancel')}
-              </Button>
-            </ButtonGroup>
-          </ModalFooter>
-        </Modal>
-      )}
+      {
+        // Remove GRB reviewer modal
+        !!reviewerToRemove && (
+          <Modal
+            isOpen={!!reviewerToRemove}
+            closeModal={() => setReviewerToRemove(null)}
+          >
+            <ModalHeading>
+              {t('removeModal.title', {
+                commonName: reviewerToRemove.userAccount.commonName
+              })}
+            </ModalHeading>
+            <p>{t('removeModal.text')}</p>
+            <ModalFooter>
+              <ButtonGroup>
+                <Button
+                  type="button"
+                  onClick={() => removeGRBReviewer(reviewerToRemove)}
+                  className="bg-error margin-right-1"
+                >
+                  {t('removeModal.remove')}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => setReviewerToRemove(null)}
+                  unstyled
+                >
+                  {t('Cancel')}
+                </Button>
+              </ButtonGroup>
+            </ModalFooter>
+          </Modal>
+        )
+      }
 
       {isForm ? (
         <GRBReviewerForm
@@ -210,6 +130,7 @@ const GRBReview = ({ id, state, grbReviewers }: GRBReviewProps) => {
       ) : (
         <div className="padding-bottom-4">
           <PageHeading className="margin-y-0">{t('title')}</PageHeading>
+
           <p className="font-body-md line-height-body-4 text-light margin-top-05 margin-bottom-3">
             {t('description')}
           </p>
@@ -231,138 +152,13 @@ const GRBReview = ({ id, state, grbReviewers }: GRBReviewProps) => {
               }}
             />
           </Alert>
-          {/* Participants table */}
-          <h2 className="margin-bottom-0">{t('participants')}</h2>
-          <p className="margin-top-05 line-height-body-5">
-            {t('participantsText')}
-          </p>
-          {isGrbView ? (
-            // GRB Reviewer documentation links
-            <div className="bg-base-lightest padding-2">
-              <h4 className="margin-top-0 margin-bottom-1">
-                {t('availableDocumentation')}
-              </h4>
-              <ButtonGroup>
-                <UswdsReactLink
-                  to={`/governance-review-board/${id}/business-case`}
-                  className="margin-right-3"
-                >
-                  {t('viewBusinessCase')}
-                </UswdsReactLink>
-                <UswdsReactLink
-                  to={`/governance-review-board/${id}/intake-request`}
-                  className="margin-right-3"
-                >
-                  {t('viewIntakeRequest')}
-                </UswdsReactLink>
-                <UswdsReactLink to={`/governance-review-board/${id}/documents`}>
-                  {t('viewOtherDocuments')}
-                </UswdsReactLink>
-              </ButtonGroup>
-            </div>
-          ) : (
-            // Add GRB reviewer button
-            <div className="desktop:display-flex flex-align-center">
-              <Button
-                type="button"
-                onClick={() => history.push(`${pathname}/add`)}
-                disabled={state === SystemIntakeState.CLOSED}
-                outline={grbReviewers.length > 0}
-              >
-                {t(
-                  grbReviewers.length > 0
-                    ? 'addAnotherGrbReviewer'
-                    : 'addGrbReviewer'
-                )}
-              </Button>
 
-              {state === SystemIntakeState.CLOSED && (
-                <p className="desktop:margin-y-0 desktop:margin-left-1">
-                  <Trans
-                    i18nKey="grbReview:closedRequest"
-                    components={{
-                      a: (
-                        <UswdsReactLink
-                          to={`/governance-review-team/${id}/resolutions/re-open-request`}
-                        >
-                          re-open
-                        </UswdsReactLink>
-                      )
-                    }}
-                  />
-                </p>
-              )}
-            </div>
-          )}
-
-          <div className="margin-top-3">
-            <Table bordered={false} fullWidth scrollable {...getTableProps()}>
-              <thead>
-                {headerGroups.map(headerGroup => (
-                  <tr {...headerGroup.getHeaderGroupProps()}>
-                    {headerGroup.headers.map((column, index) => (
-                      <th
-                        {...column.getHeaderProps(
-                          column.getSortByToggleProps()
-                        )}
-                        aria-sort={getColumnSortStatus(column)}
-                        scope="col"
-                        className="border-bottom-2px"
-                      >
-                        <Button
-                          type="button"
-                          unstyled
-                          className="width-full display-flex"
-                          {...column.getSortByToggleProps()}
-                        >
-                          <div className="flex-fill text-no-wrap">
-                            {column.render('Header')}
-                          </div>
-                          <div className="position-relative width-205 margin-left-05">
-                            {getHeaderSortIcon(column)}
-                          </div>
-                        </Button>
-                      </th>
-                    ))}
-                  </tr>
-                ))}
-              </thead>
-              <tbody {...getTableBodyProps()}>
-                {rows.map(row => {
-                  prepareRow(row);
-                  return (
-                    <tr
-                      {...row.getRowProps()}
-                      data-testid={`grbReviewer-${row.original.userAccount.username}`}
-                    >
-                      {row.cells.map((cell, index) => {
-                        return (
-                          <td {...cell.getCellProps()}>
-                            {cell.render('Cell')}
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </Table>
-
-            {rows.length === 0 && (
-              <p className="text-italic margin-top-neg-1">
-                {t('participantsTable.noReviewers')}
-              </p>
-            )}
-          </div>
-
-          {rows.length > 0 && (
-            <p
-              className="usa-sr-only usa-table__announcement-region"
-              aria-live="polite"
-            >
-              {currentTableSortDescription(headerGroups[0])}
-            </p>
-          )}
+          <ParticipantsTable
+            id={id}
+            state={state}
+            grbReviewers={grbReviewers}
+            setReviewerToRemove={setReviewerToRemove}
+          />
         </div>
       )}
     </>


### PR DESCRIPTION
# NOREF

## Description
- Moved GRB Review tab Participants table to `ParticipantsTable` component file
- Will improve readability of `GRBReview` parent component once Documents table is added
  - Prevents the need for two instances of `useTable` in one file

## How to test this change
- Go to /governance-review-team/5af245bc-fc54-4677-bab1-1b3e798bb43c/grb-review
- Participants table should still match [Figma](https://www.figma.com/design/G0UN35V7SY0g9nkTIESxsY/EASi-GRB-Experience?node-id=2266-44176&t=zYurZvpwDFv3fSd7-1)

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [ ] I have provided a detailed description of the changes in this PR.
- [ ] I have provided clear instructions on how to test the changes in this PR.
- [ ] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
