### PR TITLE
EASI-4589 Fix the requests table's status column sorting method

### DIFF
--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -6,7 +6,9 @@ import { IconError } from '@trussworks/react-uswds';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import TruncatedText from 'components/shared/TruncatedText';
+import { SystemIntakeStatusAdmin } from 'types/graphql-global-types';
 import { formatDateLocal, formatDateUtc } from 'utils/date';
+import { SystemIntakeStatusAdminIndex } from 'utils/tableRequestStatusIndex';
 
 import { SystemIntakeForTable } from './tableMap';
 
@@ -136,6 +138,26 @@ const useRequestTableColumns = (
           lcid: obj.lcid
         }
       );
+    },
+    sortType: (a: Row<SystemIntakeForTable>, b: Row<SystemIntakeForTable>) => {
+      // console.log(a.original);
+      // console.log(b.original);
+
+      const astatus = a.original.statusAdmin;
+      const bstatus = b.original.statusAdmin;
+
+      if (
+        (astatus === SystemIntakeStatusAdmin.LCID_ISSUED &&
+          bstatus === SystemIntakeStatusAdmin.LCID_ISSUED) ||
+        (astatus === SystemIntakeStatusAdmin.LCID_EXPIRED &&
+          bstatus === SystemIntakeStatusAdmin.LCID_EXPIRED)
+      ) {
+        return (a.original.lcid || '') > (b.original.lcid || '') ? 1 : -1;
+      }
+
+      const ai = SystemIntakeStatusAdminIndex[astatus];
+      const bi = SystemIntakeStatusAdminIndex[bstatus];
+      return ai > bi ? 1 : -1;
     }
   };
 

--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -147,7 +147,9 @@ const useRequestTableColumns = (
         (astatus === SystemIntakeStatusAdmin.LCID_ISSUED &&
           bstatus === SystemIntakeStatusAdmin.LCID_ISSUED) ||
         (astatus === SystemIntakeStatusAdmin.LCID_EXPIRED &&
-          bstatus === SystemIntakeStatusAdmin.LCID_EXPIRED)
+          bstatus === SystemIntakeStatusAdmin.LCID_EXPIRED) ||
+        (astatus === SystemIntakeStatusAdmin.LCID_RETIRED &&
+          bstatus === SystemIntakeStatusAdmin.LCID_RETIRED)
       ) {
         return (a.original.lcid || '') > (b.original.lcid || '') ? 1 : -1;
       }

--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -155,8 +155,8 @@ const useRequestTableColumns = (
         return (a.original.lcid || '') > (b.original.lcid || '') ? 1 : -1;
       }
 
-      const ai = SystemIntakeStatusAdminIndex[astatus];
-      const bi = SystemIntakeStatusAdminIndex[bstatus];
+      const ai = SystemIntakeStatusAdminIndex()[astatus];
+      const bi = SystemIntakeStatusAdminIndex()[bstatus];
       return ai > bi ? 1 : -1;
     }
   };

--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -140,9 +140,6 @@ const useRequestTableColumns = (
       );
     },
     sortType: (a: Row<SystemIntakeForTable>, b: Row<SystemIntakeForTable>) => {
-      // console.log(a.original);
-      // console.log(b.original);
-
       const astatus = a.original.statusAdmin;
       const bstatus = b.original.statusAdmin;
 

--- a/src/utils/tableRequestStatusIndex.ts
+++ b/src/utils/tableRequestStatusIndex.ts
@@ -1,3 +1,5 @@
+import { once } from 'lodash';
+
 import {
   SystemIntakeStatusAdmin,
   SystemIntakeStatusRequester,
@@ -12,8 +14,8 @@ import {
 // Unfortunately the order of original enums from `schema.graphql` are lost
 // when types are generated for the frontend in `global-types`.
 // Generated enum strings are maintained in such a way here for react table column sorting.
-function parseSortIndex(arr: string[]): { [v: string]: number } {
-  return Object.fromEntries(arr.map((v, i) => [v, i]));
+function parseSortIndex(arr: string[]): () => { [v: string]: number } {
+  return once(() => Object.fromEntries(arr.map((v, i) => [v, i])));
 }
 
 export const SystemIntakeStatusRequesterIndex = parseSortIndex([
@@ -83,7 +85,7 @@ export function trbRequestStatusSortType(a: any, b: any) {
       ? b.original.state
       : b.original.status;
 
-  return TRBRequestStatusIndex[astatus] > TRBRequestStatusIndex[bstatus]
+  return TRBRequestStatusIndex()[astatus] > TRBRequestStatusIndex()[bstatus]
     ? 1
     : -1;
 }

--- a/src/utils/tableRequestStatusIndex.ts
+++ b/src/utils/tableRequestStatusIndex.ts
@@ -1,20 +1,76 @@
-import { TRBRequestState, TRBRequestStatus } from 'types/graphql-global-types';
+import {
+  SystemIntakeStatusAdmin,
+  SystemIntakeStatusRequester,
+  TRBRequestState,
+  TRBRequestStatus
+} from 'types/graphql-global-types';
 
-export const TRBRequestStatusIndex = Object.fromEntries(
-  [
-    TRBRequestStatus.NEW,
-    TRBRequestStatus.DRAFT_REQUEST_FORM,
-    TRBRequestStatus.REQUEST_FORM_COMPLETE,
-    TRBRequestStatus.READY_FOR_CONSULT,
-    TRBRequestStatus.CONSULT_SCHEDULED,
-    TRBRequestStatus.CONSULT_COMPLETE,
-    TRBRequestStatus.DRAFT_ADVICE_LETTER,
-    TRBRequestStatus.ADVICE_LETTER_IN_REVIEW,
-    TRBRequestStatus.ADVICE_LETTER_SENT,
-    TRBRequestStatus.FOLLOW_UP_REQUESTED,
-    TRBRequestState.CLOSED
-  ].map((v, i) => [v, i])
-);
+/**
+ * Get a hash table of status enum strings and their status order.
+ * Used for the request table status column sort compare fn.
+ */
+// Unfortunately the order of original enums from `schema.graphql` are lost
+// when types are generated for the frontend in `global-types`.
+// Generated enum strings are maintained in such a way here for react table column sorting.
+function parseSortIndex(arr: string[]): { [v: string]: number } {
+  return Object.fromEntries(arr.map((v, i) => [v, i]));
+}
+
+export const SystemIntakeStatusRequesterIndex = parseSortIndex([
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_NEW,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_IN_PROGRESS,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_SUBMITTED,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.GRT_MEETING_READY,
+  SystemIntakeStatusRequester.GRT_MEETING_AWAITING_DECISION,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.GRB_MEETING_READY,
+  SystemIntakeStatusRequester.GRB_MEETING_AWAITING_DECISION,
+  SystemIntakeStatusRequester.LCID_ISSUED,
+  SystemIntakeStatusRequester.LCID_EXPIRED,
+  SystemIntakeStatusRequester.LCID_RETIRED,
+  SystemIntakeStatusRequester.NOT_GOVERNANCE,
+  SystemIntakeStatusRequester.NOT_APPROVED,
+  SystemIntakeStatusRequester.CLOSED
+]);
+
+export const SystemIntakeStatusAdminIndex = parseSortIndex([
+  SystemIntakeStatusAdmin.INITIAL_REQUEST_FORM_IN_PROGRESS,
+  SystemIntakeStatusAdmin.INITIAL_REQUEST_FORM_SUBMITTED,
+  SystemIntakeStatusAdmin.DRAFT_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusAdmin.DRAFT_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusAdmin.GRT_MEETING_READY,
+  SystemIntakeStatusAdmin.GRT_MEETING_COMPLETE,
+  SystemIntakeStatusAdmin.GRB_MEETING_READY,
+  SystemIntakeStatusAdmin.GRB_MEETING_COMPLETE,
+  SystemIntakeStatusAdmin.FINAL_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusAdmin.FINAL_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusAdmin.LCID_ISSUED,
+  SystemIntakeStatusAdmin.LCID_EXPIRED,
+  SystemIntakeStatusAdmin.LCID_RETIRED,
+  SystemIntakeStatusAdmin.NOT_GOVERNANCE,
+  SystemIntakeStatusAdmin.NOT_APPROVED,
+  SystemIntakeStatusAdmin.CLOSED
+]);
+
+export const TRBRequestStatusIndex = parseSortIndex([
+  TRBRequestStatus.NEW,
+  TRBRequestStatus.DRAFT_REQUEST_FORM,
+  TRBRequestStatus.REQUEST_FORM_COMPLETE,
+  TRBRequestStatus.READY_FOR_CONSULT,
+  TRBRequestStatus.CONSULT_SCHEDULED,
+  TRBRequestStatus.CONSULT_COMPLETE,
+  TRBRequestStatus.DRAFT_ADVICE_LETTER,
+  TRBRequestStatus.ADVICE_LETTER_IN_REVIEW,
+  TRBRequestStatus.ADVICE_LETTER_SENT,
+  TRBRequestStatus.FOLLOW_UP_REQUESTED,
+  TRBRequestState.CLOSED
+]);
 
 export function trbRequestStatusSortType(a: any, b: any) {
   const astatus =

--- a/src/utils/tableRequestStatusIndex.ts
+++ b/src/utils/tableRequestStatusIndex.ts
@@ -1,0 +1,33 @@
+import { TRBRequestState, TRBRequestStatus } from 'types/graphql-global-types';
+
+export const TRBRequestStatusIndex = Object.fromEntries(
+  [
+    TRBRequestStatus.NEW,
+    TRBRequestStatus.DRAFT_REQUEST_FORM,
+    TRBRequestStatus.REQUEST_FORM_COMPLETE,
+    TRBRequestStatus.READY_FOR_CONSULT,
+    TRBRequestStatus.CONSULT_SCHEDULED,
+    TRBRequestStatus.CONSULT_COMPLETE,
+    TRBRequestStatus.DRAFT_ADVICE_LETTER,
+    TRBRequestStatus.ADVICE_LETTER_IN_REVIEW,
+    TRBRequestStatus.ADVICE_LETTER_SENT,
+    TRBRequestStatus.FOLLOW_UP_REQUESTED,
+    TRBRequestState.CLOSED
+  ].map((v, i) => [v, i])
+);
+
+export function trbRequestStatusSortType(a: any, b: any) {
+  const astatus =
+    a.original.state === TRBRequestState.CLOSED
+      ? a.original.state
+      : a.original.status;
+
+  const bstatus =
+    b.original.state === TRBRequestState.CLOSED
+      ? b.original.state
+      : b.original.status;
+
+  return TRBRequestStatusIndex[astatus] > TRBRequestStatusIndex[bstatus]
+    ? 1
+    : -1;
+}

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -19,7 +19,10 @@ import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
 import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { GetRequests, GetRequestsVariables } from 'queries/types/GetRequests';
-import { RequestType } from 'types/graphql-global-types';
+import {
+  RequestType,
+  SystemIntakeStatusRequester
+} from 'types/graphql-global-types';
 import { formatDateUtc } from 'utils/date';
 import globalFilterCellText from 'utils/globalFilterCellText';
 import {
@@ -38,6 +41,29 @@ type myRequestsTableProps = {
   hiddenColumns?: string[];
   defaultPageSize?: number;
 };
+
+const SystemIntakeStatusRequesterIndex = [
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_NEW,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_IN_PROGRESS,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_SUBMITTED,
+  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.GRT_MEETING_READY,
+  SystemIntakeStatusRequester.GRT_MEETING_AWAITING_DECISION,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_IN_PROGRESS,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_SUBMITTED,
+  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_EDITS_REQUESTED,
+  SystemIntakeStatusRequester.GRB_MEETING_READY,
+  SystemIntakeStatusRequester.GRB_MEETING_AWAITING_DECISION,
+  SystemIntakeStatusRequester.LCID_ISSUED,
+  SystemIntakeStatusRequester.LCID_EXPIRED,
+  SystemIntakeStatusRequester.LCID_RETIRED,
+  SystemIntakeStatusRequester.NOT_GOVERNANCE,
+  SystemIntakeStatusRequester.NOT_APPROVED,
+  SystemIntakeStatusRequester.CLOSED
+] as const;
 
 const Table = ({
   type,
@@ -115,6 +141,13 @@ const Table = ({
             default:
               return '';
           }
+        },
+        sortType: (a: any, b: any) => {
+          const ax = a.original.statusRequester;
+          const bx = b.original.statusRequester;
+          const ai = SystemIntakeStatusRequesterIndex.indexOf(ax);
+          const bi = SystemIntakeStatusRequesterIndex.indexOf(bx);
+          return ai > bi ? 1 : -1;
         },
         width: '200px'
       },

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -140,8 +140,8 @@ const Table = ({
             return a.original.lcid > b.original.lcid ? 1 : -1;
           }
 
-          const ai = SystemIntakeStatusRequesterIndex[astatus];
-          const bi = SystemIntakeStatusRequesterIndex[bstatus];
+          const ai = SystemIntakeStatusRequesterIndex()[astatus];
+          const bi = SystemIntakeStatusRequesterIndex()[bstatus];
           return ai > bi ? 1 : -1;
         },
         width: '200px'

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -143,10 +143,25 @@ const Table = ({
           }
         },
         sortType: (a: any, b: any) => {
-          const ax = a.original.statusRequester;
-          const bx = b.original.statusRequester;
-          const ai = SystemIntakeStatusRequesterIndex.indexOf(ax);
-          const bi = SystemIntakeStatusRequesterIndex.indexOf(bx);
+          const astatus = a.original.statusRequester;
+          const bstatus = b.original.statusRequester;
+
+          if (
+            astatus === SystemIntakeStatusRequester.LCID_ISSUED &&
+            bstatus === SystemIntakeStatusRequester.LCID_ISSUED
+          ) {
+            return a.original.lcid > b.original.lcid ? 1 : -1;
+          }
+
+          if (
+            astatus === SystemIntakeStatusRequester.LCID_EXPIRED &&
+            bstatus === SystemIntakeStatusRequester.LCID_EXPIRED
+          ) {
+            return a.original.lcid > b.original.lcid ? 1 : -1;
+          }
+
+          const ai = SystemIntakeStatusRequesterIndex.indexOf(astatus);
+          const bi = SystemIntakeStatusRequesterIndex.indexOf(bstatus);
           return ai > bi ? 1 : -1;
         },
         width: '200px'

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -25,6 +25,7 @@ import {
 } from 'types/graphql-global-types';
 import { formatDateUtc } from 'utils/date';
 import globalFilterCellText from 'utils/globalFilterCellText';
+import { SystemIntakeStatusRequesterIndex } from 'utils/tableRequestStatusIndex';
 import {
   currentTableSortDescription,
   getColumnSortStatus,
@@ -41,31 +42,6 @@ type myRequestsTableProps = {
   hiddenColumns?: string[];
   defaultPageSize?: number;
 };
-
-const SystemIntakeStatusRequesterIndex = Object.fromEntries(
-  [
-    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_NEW,
-    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_IN_PROGRESS,
-    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_SUBMITTED,
-    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_EDITS_REQUESTED,
-    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_IN_PROGRESS,
-    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_SUBMITTED,
-    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_EDITS_REQUESTED,
-    SystemIntakeStatusRequester.GRT_MEETING_READY,
-    SystemIntakeStatusRequester.GRT_MEETING_AWAITING_DECISION,
-    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_IN_PROGRESS,
-    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_SUBMITTED,
-    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_EDITS_REQUESTED,
-    SystemIntakeStatusRequester.GRB_MEETING_READY,
-    SystemIntakeStatusRequester.GRB_MEETING_AWAITING_DECISION,
-    SystemIntakeStatusRequester.LCID_ISSUED,
-    SystemIntakeStatusRequester.LCID_EXPIRED,
-    SystemIntakeStatusRequester.LCID_RETIRED,
-    SystemIntakeStatusRequester.NOT_GOVERNANCE,
-    SystemIntakeStatusRequester.NOT_APPROVED,
-    SystemIntakeStatusRequester.CLOSED
-  ].map((v, i) => [v, i])
-);
 
 const Table = ({
   type,
@@ -144,14 +120,17 @@ const Table = ({
               return '';
           }
         },
+        // Check for the 3 status keys: trb requester, itgov requester & admin
+        // For each key check some matching statuses to further sort by lcid value
         sortType: (a: any, b: any) => {
-          const astatus = a.original.statusRequester;
-          const bstatus = b.original.statusRequester;
-
           // console.log(a.original);
           // console.log(b.original);
 
-          // Check some matching statuses to further sort by lcid value
+          // Only IT Gov requests are handled at this time
+
+          const astatus = a.original.statusRequester;
+          const bstatus = b.original.statusRequester;
+
           if (
             (astatus === SystemIntakeStatusRequester.LCID_ISSUED &&
               bstatus === SystemIntakeStatusRequester.LCID_ISSUED) ||

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -42,28 +42,30 @@ type myRequestsTableProps = {
   defaultPageSize?: number;
 };
 
-const SystemIntakeStatusRequesterIndex = [
-  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_NEW,
-  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_IN_PROGRESS,
-  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_SUBMITTED,
-  SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_EDITS_REQUESTED,
-  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_IN_PROGRESS,
-  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_SUBMITTED,
-  SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_EDITS_REQUESTED,
-  SystemIntakeStatusRequester.GRT_MEETING_READY,
-  SystemIntakeStatusRequester.GRT_MEETING_AWAITING_DECISION,
-  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_IN_PROGRESS,
-  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_SUBMITTED,
-  SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_EDITS_REQUESTED,
-  SystemIntakeStatusRequester.GRB_MEETING_READY,
-  SystemIntakeStatusRequester.GRB_MEETING_AWAITING_DECISION,
-  SystemIntakeStatusRequester.LCID_ISSUED,
-  SystemIntakeStatusRequester.LCID_EXPIRED,
-  SystemIntakeStatusRequester.LCID_RETIRED,
-  SystemIntakeStatusRequester.NOT_GOVERNANCE,
-  SystemIntakeStatusRequester.NOT_APPROVED,
-  SystemIntakeStatusRequester.CLOSED
-] as const;
+const SystemIntakeStatusRequesterIndex = Object.fromEntries(
+  [
+    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_NEW,
+    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_IN_PROGRESS,
+    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_SUBMITTED,
+    SystemIntakeStatusRequester.INITIAL_REQUEST_FORM_EDITS_REQUESTED,
+    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_IN_PROGRESS,
+    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_SUBMITTED,
+    SystemIntakeStatusRequester.DRAFT_BUSINESS_CASE_EDITS_REQUESTED,
+    SystemIntakeStatusRequester.GRT_MEETING_READY,
+    SystemIntakeStatusRequester.GRT_MEETING_AWAITING_DECISION,
+    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_IN_PROGRESS,
+    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_SUBMITTED,
+    SystemIntakeStatusRequester.FINAL_BUSINESS_CASE_EDITS_REQUESTED,
+    SystemIntakeStatusRequester.GRB_MEETING_READY,
+    SystemIntakeStatusRequester.GRB_MEETING_AWAITING_DECISION,
+    SystemIntakeStatusRequester.LCID_ISSUED,
+    SystemIntakeStatusRequester.LCID_EXPIRED,
+    SystemIntakeStatusRequester.LCID_RETIRED,
+    SystemIntakeStatusRequester.NOT_GOVERNANCE,
+    SystemIntakeStatusRequester.NOT_APPROVED,
+    SystemIntakeStatusRequester.CLOSED
+  ].map((v, i) => [v, i])
+);
 
 const Table = ({
   type,
@@ -146,22 +148,21 @@ const Table = ({
           const astatus = a.original.statusRequester;
           const bstatus = b.original.statusRequester;
 
+          // console.log(a.original);
+          // console.log(b.original);
+
+          // Check some matching statuses to further sort by lcid value
           if (
-            astatus === SystemIntakeStatusRequester.LCID_ISSUED &&
-            bstatus === SystemIntakeStatusRequester.LCID_ISSUED
+            (astatus === SystemIntakeStatusRequester.LCID_ISSUED &&
+              bstatus === SystemIntakeStatusRequester.LCID_ISSUED) ||
+            (astatus === SystemIntakeStatusRequester.LCID_EXPIRED &&
+              bstatus === SystemIntakeStatusRequester.LCID_EXPIRED)
           ) {
             return a.original.lcid > b.original.lcid ? 1 : -1;
           }
 
-          if (
-            astatus === SystemIntakeStatusRequester.LCID_EXPIRED &&
-            bstatus === SystemIntakeStatusRequester.LCID_EXPIRED
-          ) {
-            return a.original.lcid > b.original.lcid ? 1 : -1;
-          }
-
-          const ai = SystemIntakeStatusRequesterIndex.indexOf(astatus);
-          const bi = SystemIntakeStatusRequesterIndex.indexOf(bstatus);
+          const ai = SystemIntakeStatusRequesterIndex[astatus];
+          const bi = SystemIntakeStatusRequesterIndex[bstatus];
           return ai > bi ? 1 : -1;
         },
         width: '200px'

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -154,7 +154,9 @@ const Table = ({
               (astatus === SystemIntakeStatusRequester.LCID_ISSUED &&
                 bstatus === SystemIntakeStatusRequester.LCID_ISSUED) ||
               (astatus === SystemIntakeStatusRequester.LCID_EXPIRED &&
-                bstatus === SystemIntakeStatusRequester.LCID_EXPIRED)
+                bstatus === SystemIntakeStatusRequester.LCID_EXPIRED) ||
+              (astatus === SystemIntakeStatusRequester.LCID_RETIRED &&
+                bstatus === SystemIntakeStatusRequester.LCID_RETIRED)
             ) {
               return a.original.lcid > b.original.lcid ? 1 : -1;
             }

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -53,19 +53,10 @@ const tableMap = (
           ? t(`requestsTable.types.${request.type}`)
           : t(`requestsTable.types.TRB`);
 
-      let status = '';
-      if (isTRBRequestType(request)) {
-        // TRB status
-        status = t(`table.requestStatus.${request.status}`, {
-          ns: 'technicalAssistance'
-        });
-      }
-
       return {
         ...request,
         name,
-        type,
-        status
+        type
       };
     });
 

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -99,8 +99,7 @@ function Homepage() {
           state === TRBRequestState.CLOSED
             ? t(`table.requestState.${state}`)
             : t(`table.requestStatus.${status}`),
-        sortType: trbRequestStatusSortType,
-        width: '200px'
+        sortType: trbRequestStatusSortType
       },
       {
         Header: t<string>('table.header.submissionDate'),

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -43,6 +43,7 @@ import { AppState } from 'reducers/rootReducer';
 import { TRBRequestState } from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
 import globalFilterCellText from 'utils/globalFilterCellText';
+import { trbRequestStatusSortType } from 'utils/tableRequestStatusIndex';
 import {
   currentTableSortDescription,
   getColumnSortStatus,
@@ -97,7 +98,9 @@ function Homepage() {
         accessor: ({ status, state }) =>
           state === TRBRequestState.CLOSED
             ? t(`table.requestState.${state}`)
-            : t(`table.requestStatus.${status}`)
+            : t(`table.requestStatus.${status}`),
+        sortType: trbRequestStatusSortType,
+        width: '200px'
       },
       {
         Header: t<string>('table.header.submissionDate'),

--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
@@ -38,6 +38,7 @@ import { formatDateLocal } from 'utils/date';
 import formatContractNumbers from 'utils/formatContractNumbers';
 import { getPersonNameAndComponentVal } from 'utils/getPersonNameAndComponent';
 import globalFilterCellText from 'utils/globalFilterCellText';
+import { trbRequestStatusSortType } from 'utils/tableRequestStatusIndex';
 import {
   currentTableSortDescription,
   getColumnSortStatus,
@@ -379,7 +380,8 @@ function TrbExistingRequestsTable({ requests }: TrbRequestsTableProps) {
         accessor: ({ status, state }) =>
           state === TRBRequestState.CLOSED
             ? t(`table.requestState.${state}`)
-            : t(`table.requestStatus.${status}`)
+            : t(`table.requestStatus.${status}`),
+        sortType: trbRequestStatusSortType
       },
       {
         Header: t<string>('table.header.trbConsultDate'),


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [EASI-1234] [EASI-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# EASI-4589



## Description
<!--
REQUIRED
    Provide details as to what the PR aims to accomplish
    Be as descriptive as you can, and include any relevant information that will help the reviewer understand the scope of the changes
    Include screenshots or screen recordings to assist in reviewing if possible.
-->
Table's status column needs to sort by status enums.

This also introduces `utils/tableRequestStatusIndex.ts` to maintain sort indexes.
Tables were initially made to leave status columns up to alphabetical sorting, if at all.

Bug originally found on the ITGOV table.

**Before**
<hr>
<img src="https://github.com/user-attachments/assets/0b7cad9c-272b-41b0-b33f-9b9d7346c223" width="500">
<hr>

**After**
<hr>
<img width="500" alt="Screen Shot 2024-08-19 at 12 41 07 PM" src="https://github.com/user-attachments/assets/d7267884-d3fd-4d39-9312-dafe8364ad2d">
<hr>


## How to test this change
<!--
REQUIRED
    Add instructions on how to test the changes in this PR
    This can be a list of steps to reproduce a bug, or a list of steps to verify a feature in the application
    Include any example shell commands or postman requests that reviewers can run to test the changes
-->
- Check table instances on local dev seeded
  - Make sure that the request status columns follow the order of the original enums
    - [SystemIntakeStatusRequester](https://github.com/CMS-Enterprise/easi-app/blob/EASI-4589/status_sort/pkg/graph/schema.graphql#L2879)
    - [SystemIntakeStatusAdmin](https://github.com/CMS-Enterprise/easi-app/blob/EASI-4589/status_sort/pkg/graph/schema.graphql#L2857)
    - [TRBRequestStatus](https://github.com/CMS-Enterprise/easi-app/blob/EASI-4589/status_sort/pkg/graph/schema.graphql#L2561)
  - As USR1 : Job None or EASI_P_USER
    - homepage my open requests (combo request type)
    - it gov tab my requests table
    - technical tab my requests table
  - EASI_TRB_ADMIN_D
    - homepage trb admin existing requests table
  - EASI_D_GOVTEAM
    - it gov admin homepage  

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [ ] I have provided a detailed description of the changes in this PR.
- [ ] I have provided clear instructions on how to test the changes in this PR.
- [ ] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
