### PR TITLE
Restore Contract Information text

### DIFF
--- a/src/i18n/en-US/systemProfile.ts
+++ b/src/i18n/en-US/systemProfile.ts
@@ -172,7 +172,8 @@ const systemProfile = {
         fte: 'Full-time employees (FTE)',
         businessOwners: 'Business Owners',
         projectLeads: 'Project Leads',
-        additional: 'Additional team members'
+        additional: 'Additional team members',
+        contractInformation: 'Contract Information'
       },
       noData: {
         businessOwners:


### PR DESCRIPTION
Fixes this broken i18n key for Contract Information
![image_720](https://github.com/user-attachments/assets/f21969b7-35d7-4a34-8dc9-a8ed79574145)

> [!NOTE]
> The Contract Info section is behind the `systemProfileHiddenFields` flag, and vendors is static mock data.