### PR TITLE
[NOREF] RTE z-index bug

### DIFF
--- a/src/components/RichTextEditor/index.scss
+++ b/src/components/RichTextEditor/index.scss
@@ -58,6 +58,7 @@
   }
 
   .toastui-editor-defaultUI {
+    // z-index of 0 here prevents a few strange interactions with other UI elements not being clickable when they overlap the editor
     z-index: 0;
     border-color: color('gray-60');
     border-radius: 0;

--- a/src/components/RichTextEditor/index.scss
+++ b/src/components/RichTextEditor/index.scss
@@ -58,6 +58,7 @@
   }
 
   .toastui-editor-defaultUI {
+    z-index: 0;
     border-color: color('gray-60');
     border-radius: 0;
   }


### PR DESCRIPTION
# NOREF

## Description
- When adding an admin note to a TRB request, the rich text editor was blocking selecting a guidance option from the dropdown
  - See [slack thread](https://oddball.slack.com/archives/C059N01AYGM/p1731077682370609?thread_ts=1731074413.177179&cid=C059N01AYGM)
- Set editor z-index to 0 to fix bug


## How to test this change

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [ ] I have provided a detailed description of the changes in this PR.
- [ ] I have provided clear instructions on how to test the changes in this PR.
- [ ] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
