### PR TITLE
[NOREF] Guidance letter save bug

### DIFF
--- a/src/views/TechnicalAssistance/GuidanceLetterForm/NextSteps.tsx
+++ b/src/views/TechnicalAssistance/GuidanceLetterForm/NextSteps.tsx
@@ -12,7 +12,10 @@ import {
   Radio,
   TextInput
 } from '@trussworks/react-uswds';
-import { useUpdateTRBGuidanceLetterMutation } from 'gql/gen/graphql';
+import {
+  GetTRBGuidanceLetterDocument,
+  useUpdateTRBGuidanceLetterMutation
+} from 'gql/gen/graphql';
 
 import useEasiForm from 'components/EasiForm/useEasiForm';
 import RichTextEditor from 'components/RichTextEditor';
@@ -39,7 +42,9 @@ const NextSteps = ({
 
   const { nextSteps, isFollowupRecommended, followupPoint } = guidanceLetter;
 
-  const [update] = useUpdateTRBGuidanceLetterMutation();
+  const [update] = useUpdateTRBGuidanceLetterMutation({
+    refetchQueries: [GetTRBGuidanceLetterDocument]
+  });
 
   const {
     partialSubmit,

--- a/src/views/TechnicalAssistance/GuidanceLetterForm/Summary.tsx
+++ b/src/views/TechnicalAssistance/GuidanceLetterForm/Summary.tsx
@@ -5,7 +5,10 @@ import { useHistory } from 'react-router-dom';
 import { ApolloError } from '@apollo/client';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ErrorMessage, Form, FormGroup } from '@trussworks/react-uswds';
-import { useUpdateTRBGuidanceLetterMutation } from 'gql/gen/graphql';
+import {
+  GetTRBGuidanceLetterDocument,
+  useUpdateTRBGuidanceLetterMutation
+} from 'gql/gen/graphql';
 
 import useEasiForm from 'components/EasiForm/useEasiForm';
 import RichTextEditor from 'components/RichTextEditor';
@@ -32,7 +35,9 @@ const Summary = ({
 
   const { meetingSummary } = guidanceLetter;
 
-  const [update] = useUpdateTRBGuidanceLetterMutation();
+  const [update] = useUpdateTRBGuidanceLetterMutation({
+    refetchQueries: [GetTRBGuidanceLetterDocument]
+  });
 
   const {
     handleSubmit,


### PR DESCRIPTION
# NOREF

## Description
- Guidance letter "next steps" step seemed to not save values
  - See [slack thread](https://oddball.slack.com/archives/C059N01AYGM/p1731081683189919?thread_ts=1731074413.177179&cid=C059N01AYGM)
- Guidance letter query needed to be refetched after executing `updateTRBGuidanceLettern` mutation

## How to test this change
1. Create guidance letter
2. Fill guidance letter fields
3. Click "Save and return to request"
4. Go back to guidance letter
5. Make changes on "Next Steps" fields
6. Changes should save and show correct values in "Internal review" step

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
