### PR TITLE
[NOREF] Sort admin lead list

### DIFF
--- a/src/i18n/en-US/articles/governanceReviewTeam.ts
+++ b/src/i18n/en-US/articles/governanceReviewTeam.ts
@@ -321,16 +321,16 @@ const governanceReviewTeam = {
     members: [
       'Alex Smith',
       'Ashley Marks',
+      'Dominese Withers',
       'Emily Hill',
       'Jaime Cadwell',
+      'Kayla Jones',
       'Leah Nguyen',
       'Leilani Fields',
       'Nicholas Downey',
       'Savannah Huttenberger',
       'Tara Ross',
-      'Valerie Hartz',
-      'Dominese Withers',
-      'Kayla Jones'
+      'Valerie Hartz'
     ]
   }
 };


### PR DESCRIPTION
# NO REF

## Description
- Follow up to [PR 2941](https://github.com/CMS-Enterprise/easi-app/pull/2941) that sorts the list of selectable Admin Leads alphabetically by first name.

## How to test this change
- Run/seed the app and open an intake as an admin. Click the "change admin lead" link on the overview page.

## PR Author Checklist
- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
