### PR TITLE
[EASI-4794] Fix presentation link downloaded file names

### DIFF
--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -564,7 +564,7 @@ describe('Governance Review Team', () => {
 
     cy.contains('button', 'View transcript').should('be.visible');
 
-    cy.contains('a', 'View slide deck').should('be.visible');
+    cy.contains('button', 'View slide deck').should('be.visible');
 
     // Edit presentation links
     cy.contains('a', 'Edit presentation links').click();

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.test.tsx
@@ -57,13 +57,14 @@ describe('Async Presentation Links Card', () => {
 
     screen.getByRole('button', { name: 'View recording' });
     screen.getByText(formattedRecordingPasscode);
-    screen.getByRole('link', { name: 'View transcript' });
-    screen.getByRole('link', { name: 'View slide deck' });
+    screen.getByRole('button', { name: 'View transcript' });
+    screen.getByRole('button', { name: 'View slide deck' });
   });
 
   it('renders the transcript link', () => {
     renderCard({
       ...grbPresentationLinksMock,
+      transcriptFileStatus: SystemIntakeDocumentStatus.UNAVAILABLE,
       transcriptLink: 'http://transcriptlink.com'
     });
 
@@ -107,7 +108,7 @@ describe('Async Presentation Links Card', () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole('link', { name: 'View slide deck' })
+      screen.queryByRole('button', { name: 'View slide deck' })
     ).not.toBeInTheDocument();
   });
 

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
@@ -23,6 +23,7 @@ import IconLink from 'components/IconLink';
 import UswdsReactLink from 'components/LinkWrapper';
 import Modal from 'components/Modal';
 import useMessage from 'hooks/useMessage';
+import { downloadFileFromURL } from 'utils/downloadFile';
 
 import ITGovAdminContext from '../ITGovAdminContext';
 
@@ -47,6 +48,7 @@ function PresentationLinksCard({
     transcriptLink,
     transcriptFileStatus,
     transcriptFileURL,
+    presentationDeckFileName,
     presentationDeckFileStatus,
     presentationDeckFileURL
   } = grbPresentationLinks || {};
@@ -193,14 +195,20 @@ function PresentationLinksCard({
 
                 {presentationDeckFileStatus ===
                   SystemIntakeDocumentStatus.AVAILABLE &&
-                  presentationDeckFileURL && (
-                    <Link
-                      href={presentationDeckFileURL}
-                      target="_blank"
-                      data-testid="presentation-url"
+                  presentationDeckFileURL &&
+                  presentationDeckFileName && (
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        downloadFileFromURL(
+                          presentationDeckFileURL,
+                          presentationDeckFileName
+                        )
+                      }
+                      unstyled
                     >
                       {t('asyncPresentation.viewSlideDeck')}
-                    </Link>
+                    </Button>
                   )}
               </>
             )}

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
@@ -7,7 +7,6 @@ import {
   CardFooter,
   CardHeader,
   Icon,
-  Link,
   ModalHeading
 } from '@trussworks/react-uswds';
 import classNames from 'classnames';
@@ -46,6 +45,7 @@ function PresentationLinksCard({
     recordingLink,
     recordingPasscode,
     transcriptLink,
+    transcriptFileName,
     transcriptFileStatus,
     transcriptFileURL,
     presentationDeckFileName,
@@ -186,14 +186,20 @@ function PresentationLinksCard({
 
                 {transcriptFileStatus ===
                   SystemIntakeDocumentStatus.AVAILABLE &&
-                  transcriptFileURL && (
-                    <Link
-                      href={transcriptFileURL}
-                      target="_blank"
-                      data-testid="transcript-url"
+                  transcriptFileURL &&
+                  transcriptFileName && (
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        downloadFileFromURL(
+                          transcriptFileURL,
+                          transcriptFileName
+                        )
+                      }
+                      unstyled
                     >
                       {t('asyncPresentation.viewTranscript')}
-                    </Link>
+                    </Button>
                   )}
 
                 {presentationDeckFileStatus ===

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard.tsx
@@ -153,27 +153,30 @@ function PresentationLinksCard({
               </em>
             ) : (
               <>
-                <div className="display-flex flex-wrap flex-gap-1">
-                  {recordingLink && (
-                    <ExternalLinkAndModal href={recordingLink}>
-                      {t('asyncPresentation.viewRecording')}
-                    </ExternalLinkAndModal>
-                  )}
+                {(recordingLink || recordingPasscode || transcriptLink) && (
+                  <div className="display-flex flex-wrap flex-gap-1">
+                    {recordingLink && (
+                      <ExternalLinkAndModal href={recordingLink}>
+                        {t('asyncPresentation.viewRecording')}
+                      </ExternalLinkAndModal>
+                    )}
 
-                  {!recordingLink && (recordingPasscode || transcriptLink) && (
-                    <span>
-                      {t('asyncPresentation.noRecordingLinkAvailable')}
-                    </span>
-                  )}
+                    {!recordingLink &&
+                      (recordingPasscode || transcriptLink) && (
+                        <span>
+                          {t('asyncPresentation.noRecordingLinkAvailable')}
+                        </span>
+                      )}
 
-                  {recordingPasscode && (
-                    <span className="text-base">
-                      {t('asyncPresentation.passcode', {
-                        passcode: recordingPasscode
-                      })}
-                    </span>
-                  )}
-                </div>
+                    {recordingPasscode && (
+                      <span className="text-base">
+                        {t('asyncPresentation.passcode', {
+                          passcode: recordingPasscode
+                        })}
+                      </span>
+                    )}
+                  </div>
+                )}
 
                 {transcriptLink && (
                   <ExternalLinkAndModal href={transcriptLink}>


### PR DESCRIPTION
# EASI-4794

## Description
- Fixed downloaded file names when clicking "View transcript" and "View slide deck" links from presentation links card
  - Files were downloading as {id}.pdf instead of {filename}.pdf

## How to test this change
- Go to presentation links form (/it-governance/:systemId/grb-review/presentation-links)
- Upload files for both presentation deck and transcript fields
- Submit form
- Run `scripts/dev minio:clean` to complete virus scan so you can download files
- Test "View transcript" and "View slide deck" buttons on presentation links card
- Downloaded file names should match uploaded files

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
