### PR TITLE
[EASI-4858] Requester discussions task list updates

### DIFF
--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/__snapshots__/index.test.tsx.snap
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Requester discussions card > matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-base-lightest padding-2 margin-top-2"
+    data-testid="requester-discussions-card"
+  >
+    <p
+      class="display-flex flex-align-center"
+    >
+      <svg
+        class="usa-icon margin-right-1"
+        focusable="false"
+        height="1em"
+        role="img"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 9h-2V5h2v6zm0 4h-2v-2h2v2z"
+        />
+      </svg>
+      <span>
+        <span
+          class="text-bold"
+          data-testid="discussions-without-replies"
+        >
+          4
+        </span>
+         discussions without replies, 
+        <span
+          class="text-bold"
+          data-testid="discussions-total"
+        >
+          5
+        </span>
+         discussions total
+      </span>
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/__snapshots__/index.test.tsx.snap
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/__snapshots__/index.test.tsx.snap
@@ -39,6 +39,35 @@ exports[`Requester discussions card > matches the snapshot 1`] = `
          discussions total
       </span>
     </p>
+    <div
+      class="easi-divider margin-y-2"
+    />
+    <ul
+      class="usa-button-group"
+    >
+      <li
+        class="usa-button-group__item"
+      >
+        <button
+          class="usa-button margin-right-1"
+          data-testid="button"
+          type="button"
+        >
+          View discussion board
+        </button>
+      </li>
+      <li
+        class="usa-button-group__item"
+      >
+        <button
+          class="usa-button usa-button--unstyled"
+          data-testid="button"
+          type="button"
+        >
+          Start a discussion
+        </button>
+      </li>
+    </ul>
   </div>
 </DocumentFragment>
 `;

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
@@ -26,9 +26,7 @@ describe('Requester discussions card', () => {
       </VerboseMockedProvider>
     );
 
-    expect(
-      await screen.findByTestId('requester-discussions-card')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('discussions-total')).toBeInTheDocument();
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ITGovGRBStatus } from 'gql/generated/graphql';
+import {
+  getSystemIntakeGRBDiscussionsQuery,
+  mockDiscussions,
+  mockDiscussionsWithoutReplies
+} from 'tests/mock/discussions';
+import { systemIntake } from 'tests/mock/systemIntake';
+
+import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
+
+import RequesterDiscussionsCard from '.';
+
+const discussions = mockDiscussions();
+const discussionsWithoutReplies = mockDiscussionsWithoutReplies();
+
+describe('Requester discussions card', () => {
+  it('matches the snapshot', async () => {
+    const { asFragment } = render(
+      <VerboseMockedProvider mocks={[getSystemIntakeGRBDiscussionsQuery()]}>
+        <RequesterDiscussionsCard
+          systemIntakeId={systemIntake.id}
+          grbMeetingStatus={ITGovGRBStatus.REVIEW_IN_PROGRESS}
+        />
+      </VerboseMockedProvider>
+    );
+
+    expect(
+      await screen.findByTestId('requester-discussions-card')
+    ).toBeInTheDocument();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders completed with no discussions', async () => {
+    render(
+      <VerboseMockedProvider
+        mocks={[
+          getSystemIntakeGRBDiscussionsQuery({ grbDiscussionsPrimary: [] })
+        ]}
+      >
+        <RequesterDiscussionsCard
+          systemIntakeId={systemIntake.id}
+          grbMeetingStatus={ITGovGRBStatus.COMPLETED}
+        />
+      </VerboseMockedProvider>
+    );
+
+    expect(
+      await screen.findByText('There were no discussions during this review.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders in progress with no discussions', async () => {
+    render(
+      <VerboseMockedProvider
+        mocks={[
+          getSystemIntakeGRBDiscussionsQuery({ grbDiscussionsPrimary: [] })
+        ]}
+      >
+        <RequesterDiscussionsCard
+          systemIntakeId={systemIntake.id}
+          grbMeetingStatus={ITGovGRBStatus.REVIEW_IN_PROGRESS}
+        />
+      </VerboseMockedProvider>
+    );
+
+    expect(
+      await screen.findByText(
+        'There are not yet any discussions for this review.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders the correct number of discussions', async () => {
+    render(
+      <VerboseMockedProvider mocks={[getSystemIntakeGRBDiscussionsQuery()]}>
+        <RequesterDiscussionsCard
+          systemIntakeId={systemIntake.id}
+          grbMeetingStatus={ITGovGRBStatus.REVIEW_IN_PROGRESS}
+        />
+      </VerboseMockedProvider>
+    );
+
+    // Check discussion counts
+    expect(
+      await screen.findByTestId('discussions-without-replies')
+    ).toHaveTextContent(`${discussionsWithoutReplies.length}`);
+
+    expect(await screen.findByTestId('discussions-total')).toHaveTextContent(
+      `${discussions.length + discussionsWithoutReplies.length}`
+    );
+  });
+});

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
@@ -50,6 +50,11 @@ describe('Requester discussions card', () => {
     expect(
       await screen.findByText('There were no discussions during this review.')
     ).toBeInTheDocument();
+
+    // Start a discussion button should be hidden when awaiting decision
+    expect(
+      screen.queryByRole('button', { name: 'Start a discussion' })
+    ).toBeNull();
   });
 
   it('renders in progress with no discussions', async () => {

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.test.tsx
@@ -33,7 +33,7 @@ describe('Requester discussions card', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('renders completed with no discussions', async () => {
+  it('renders awaiting decision status with no discussions', async () => {
     render(
       <VerboseMockedProvider
         mocks={[
@@ -42,7 +42,7 @@ describe('Requester discussions card', () => {
       >
         <RequesterDiscussionsCard
           systemIntakeId={systemIntake.id}
-          grbMeetingStatus={ITGovGRBStatus.COMPLETED}
+          grbMeetingStatus={ITGovGRBStatus.AWAITING_DECISION}
         />
       </VerboseMockedProvider>
     );

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
@@ -77,12 +77,22 @@ const RequesterDiscussionsCard = ({
       <Divider className="margin-y-2" />
 
       <ButtonGroup>
-        <Button type="button" onClick={() => null} className="margin-right-1">
+        <Button
+          type="button"
+          // TODO EASI-4857: update to open primary discussion board
+          onClick={() => null}
+          className="margin-right-1"
+        >
           {t('general.viewDiscussionBoard')}
         </Button>
 
         {grbMeetingStatus !== ITGovGRBStatus.AWAITING_DECISION && (
-          <Button type="button" onClick={() => null} unstyled>
+          <Button
+            type="button"
+            // TODO EASI-4857: update to open primary discussion board
+            onClick={() => null}
+            unstyled
+          >
             {t('general.startDiscussion.heading')}
           </Button>
         )}

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Icon } from '@trussworks/react-uswds';
 import {
   ITGovGRBStatus,
@@ -36,16 +36,33 @@ const RequesterDiscussionsCard = ({
   if (loading || !grbDiscussionsPrimary) return null;
 
   return (
-    <div className="bg-base-lightest padding-2 margin-top-2">
+    <div
+      className="bg-base-lightest padding-2 margin-top-2"
+      data-testid="requester-discussions-card"
+    >
       <p className="display-flex flex-align-center">
         <Icon.Announcement className="margin-right-1" />
 
-        {grbDiscussionsPrimary.length === 0
-          ? t('taskList.noDiscussions', { context: grbMeetingStatus })
-          : t('taskList.discussionsCount', {
-              count: grbDiscussionsPrimary.length,
-              discussionsWithoutRepliesCount
-            })}
+        {grbDiscussionsPrimary.length === 0 ? (
+          t('taskList.noDiscussions', { context: grbMeetingStatus })
+        ) : (
+          <span>
+            <Trans
+              i18nKey="discussions:taskList.discussionsCount"
+              values={{
+                count: grbDiscussionsPrimary.length,
+                discussionsWithoutRepliesCount
+              }}
+              components={[
+                <span
+                  className="text-bold"
+                  data-testid="discussions-without-replies"
+                />,
+                <span className="text-bold" data-testid="discussions-total" />
+              ]}
+            />
+          </span>
+        )}
       </p>
     </div>
   );

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '@trussworks/react-uswds';
+import {
+  ITGovGRBStatus,
+  useGetSystemIntakeGRBDiscussionsQuery
+} from 'gql/generated/graphql';
+
+type RequesterDiscussionsCardProps = {
+  systemIntakeId: string;
+  grbMeetingStatus: ITGovGRBStatus;
+};
+
+const RequesterDiscussionsCard = ({
+  systemIntakeId,
+  grbMeetingStatus
+}: RequesterDiscussionsCardProps) => {
+  const { t } = useTranslation('discussions');
+
+  const { data, loading } = useGetSystemIntakeGRBDiscussionsQuery({
+    variables: { id: systemIntakeId }
+  });
+
+  const grbDiscussionsPrimary = useMemo(
+    () => data?.systemIntake?.grbDiscussionsPrimary,
+    [data]
+  );
+
+  const discussionsWithoutRepliesCount = useMemo(() => {
+    if (!grbDiscussionsPrimary) return 0;
+
+    return grbDiscussionsPrimary.filter(({ replies }) => replies.length === 0)
+      .length;
+  }, [grbDiscussionsPrimary]);
+
+  if (loading || !grbDiscussionsPrimary) return null;
+
+  return (
+    <div className="bg-base-lightest padding-2 margin-top-2">
+      <p className="display-flex flex-align-center">
+        <Icon.Announcement className="margin-right-1" />
+
+        {grbDiscussionsPrimary.length === 0
+          ? t('taskList.noDiscussions', { context: grbMeetingStatus })
+          : t('taskList.discussionsCount', {
+              count: grbDiscussionsPrimary.length,
+              discussionsWithoutRepliesCount
+            })}
+      </p>
+    </div>
+  );
+};
+
+export default RequesterDiscussionsCard;

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
@@ -1,16 +1,22 @@
 import React, { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Icon } from '@trussworks/react-uswds';
+import { Button, ButtonGroup, Icon } from '@trussworks/react-uswds';
 import {
   ITGovGRBStatus,
   useGetSystemIntakeGRBDiscussionsQuery
 } from 'gql/generated/graphql';
+
+import Divider from 'components/Divider';
 
 type RequesterDiscussionsCardProps = {
   systemIntakeId: string;
   grbMeetingStatus: ITGovGRBStatus;
 };
 
+/**
+ * Displays Primary Discussion Board information for requesters
+ * with buttons to view and start discussions
+ */
 const RequesterDiscussionsCard = ({
   systemIntakeId,
   grbMeetingStatus
@@ -64,6 +70,20 @@ const RequesterDiscussionsCard = ({
           </span>
         )}
       </p>
+
+      <Divider className="margin-y-2" />
+
+      <ButtonGroup>
+        <Button type="button" onClick={() => null} className="margin-right-1">
+          {t('general.viewDiscussionBoard')}
+        </Button>
+
+        {grbMeetingStatus !== ITGovGRBStatus.AWAITING_DECISION && (
+          <Button type="button" onClick={() => null} unstyled>
+            {t('general.startDiscussion.heading')}
+          </Button>
+        )}
+      </ButtonGroup>
     </div>
   );
 };

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/_components/RequesterDiscussionsCard/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'gql/generated/graphql';
 
 import Divider from 'components/Divider';
+import Spinner from 'components/Spinner';
 
 type RequesterDiscussionsCardProps = {
   systemIntakeId: string;
@@ -39,37 +40,39 @@ const RequesterDiscussionsCard = ({
       .length;
   }, [grbDiscussionsPrimary]);
 
-  if (loading || !grbDiscussionsPrimary) return null;
-
   return (
     <div
       className="bg-base-lightest padding-2 margin-top-2"
       data-testid="requester-discussions-card"
     >
-      <p className="display-flex flex-align-center">
-        <Icon.Announcement className="margin-right-1" />
+      {loading ? (
+        <Spinner />
+      ) : (
+        <p className="display-flex flex-align-center">
+          <Icon.Announcement className="margin-right-1" />
 
-        {grbDiscussionsPrimary.length === 0 ? (
-          t('taskList.noDiscussions', { context: grbMeetingStatus })
-        ) : (
-          <span>
-            <Trans
-              i18nKey="discussions:taskList.discussionsCount"
-              values={{
-                count: grbDiscussionsPrimary.length,
-                discussionsWithoutRepliesCount
-              }}
-              components={[
-                <span
-                  className="text-bold"
-                  data-testid="discussions-without-replies"
-                />,
-                <span className="text-bold" data-testid="discussions-total" />
-              ]}
-            />
-          </span>
-        )}
-      </p>
+          {grbDiscussionsPrimary?.length === 0 ? (
+            t('taskList.noDiscussions', { context: grbMeetingStatus })
+          ) : (
+            <span>
+              <Trans
+                i18nKey="discussions:taskList.discussionsCount"
+                values={{
+                  count: grbDiscussionsPrimary?.length,
+                  discussionsWithoutRepliesCount
+                }}
+                components={[
+                  <span
+                    className="text-bold"
+                    data-testid="discussions-without-replies"
+                  />,
+                  <span className="text-bold" data-testid="discussions-total" />
+                ]}
+              />
+            </span>
+          )}
+        </p>
+      )}
 
       <Divider className="margin-y-2" />
 

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.test.tsx
@@ -6,6 +6,7 @@ import {
   SystemIntakeGRBReviewType
 } from 'gql/generated/graphql';
 import i18next from 'i18next';
+import { getSystemIntakeGRBDiscussionsQuery } from 'tests/mock/discussions';
 import { taskListState } from 'tests/mock/govTaskList';
 
 import { MessageProvider } from 'hooks/useMessage';
@@ -23,7 +24,7 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
   function renderGovTaskGrbMeeting(mockdata: ITGovTaskSystemIntake) {
     return render(
       <MemoryRouter>
-        <VerboseMockedProvider>
+        <VerboseMockedProvider mocks={[getSystemIntakeGRBDiscussionsQuery()]}>
           <MessageProvider>
             <GovTaskGrbMeeting {...mockdata} />
           </MessageProvider>
@@ -39,6 +40,9 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       expectTaskStatusTagToHaveTextKey('CANT_START');
       // Link to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+
+      // Hides discussions card
+      expect(screen.queryByTestId('requester-discussions-card')).toBeNull();
     });
 
     it('Skipped', () => {
@@ -47,6 +51,9 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       expectTaskStatusTagToHaveTextKey('NOT_NEEDED');
       // Link to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+
+      // Hides discussions card
+      expect(screen.queryByTestId('requester-discussions-card')).toBeNull();
     });
 
     it('In progress - not scheduled', () => {
@@ -57,6 +64,11 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       expectTaskStatusTagToHaveTextKey('READY_TO_SCHEDULE');
       // Button to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+
+      // Renders discussions card
+      expect(
+        screen.getByTestId('requester-discussions-card')
+      ).toBeInTheDocument();
     });
 
     it('In progress - scheduled', () => {
@@ -83,6 +95,11 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       ).toBeInTheDocument();
       // Button to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+
+      // Renders discussions card
+      expect(
+        screen.getByTestId('requester-discussions-card')
+      ).toBeInTheDocument();
     });
 
     it('Done', () => {
@@ -100,6 +117,9 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       );
       // Link to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+
+      // Hides discussions card
+      expect(screen.queryByTestId('requester-discussions-card')).toBeNull();
     });
   });
   describe('Async GRB Meeting', () => {

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.test.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.test.tsx
@@ -65,10 +65,8 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       // Button to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
 
-      // Renders discussions card
-      expect(
-        screen.getByTestId('requester-discussions-card')
-      ).toBeInTheDocument();
+      // Hides discussions card
+      expect(screen.queryByTestId('requester-discussions-card')).toBeNull();
     });
 
     it('In progress - scheduled', () => {
@@ -96,10 +94,8 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       // Button to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
 
-      // Renders discussions card
-      expect(
-        screen.getByTestId('requester-discussions-card')
-      ).toBeInTheDocument();
+      // Hides discussions card
+      expect(screen.queryByTestId('requester-discussions-card')).toBeNull();
     });
 
     it('Done', () => {
@@ -182,6 +178,19 @@ describe('Gov Task: Attend the GRB meeting statuses', () => {
       );
       // Button to prep grb meeting
       getByRoleWithNameTextKey('link', 'itGov:taskList.step.grbMeeting.button');
+    });
+
+    it('In progress - awaiting decision', () => {
+      const modifiedMock = {
+        ...taskListState.grbMeetingAwaitingDecision.systemIntake!,
+        grbReviewType: SystemIntakeGRBReviewType.ASYNC
+      };
+      renderGovTaskGrbMeeting(modifiedMock);
+
+      // renders the discussion card
+      expect(
+        screen.getByTestId('requester-discussions-card')
+      ).toBeInTheDocument();
     });
 
     it('Done', () => {

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
@@ -87,6 +87,15 @@ const GovTaskGrbMeeting = ({
       });
   };
 
+  /** Discussions card should only render if review is in progress */
+  const renderDiscussionsCard = [
+    ITGovGRBStatus.AWAITING_DECISION,
+    ITGovGRBStatus.AWAITING_GRB_REVIEW,
+    ITGovGRBStatus.READY_TO_SCHEDULE,
+    ITGovGRBStatus.REVIEW_IN_PROGRESS,
+    ITGovGRBStatus.SCHEDULED
+  ].includes(grbMeetingStatus);
+
   return (
     <>
       {/* Remove Presentation Modal */}
@@ -285,10 +294,12 @@ const GovTaskGrbMeeting = ({
               </>
             )}
 
-          <RequesterDiscussionsCard
-            systemIntakeId={id}
-            grbMeetingStatus={grbMeetingStatus}
-          />
+          {renderDiscussionsCard && (
+            <RequesterDiscussionsCard
+              systemIntakeId={id}
+              grbMeetingStatus={grbMeetingStatus}
+            />
+          )}
 
           <div className="margin-top-2 display-flex flex-align-center">
             <UswdsReactLink

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
@@ -87,15 +87,6 @@ const GovTaskGrbMeeting = ({
       });
   };
 
-  /** Discussions card should only render if review is in progress */
-  const renderDiscussionsCard = [
-    ITGovGRBStatus.AWAITING_DECISION,
-    ITGovGRBStatus.AWAITING_GRB_REVIEW,
-    ITGovGRBStatus.READY_TO_SCHEDULE,
-    ITGovGRBStatus.REVIEW_IN_PROGRESS,
-    ITGovGRBStatus.SCHEDULED
-  ].includes(grbMeetingStatus);
-
   return (
     <>
       {/* Remove Presentation Modal */}
@@ -294,12 +285,17 @@ const GovTaskGrbMeeting = ({
               </>
             )}
 
-          {renderDiscussionsCard && (
-            <RequesterDiscussionsCard
-              systemIntakeId={id}
-              grbMeetingStatus={grbMeetingStatus}
-            />
-          )}
+          {
+            /** Discussions card */
+            // Only render if review is active
+            (grbMeetingStatus === ITGovGRBStatus.AWAITING_DECISION ||
+              grbMeetingStatus === ITGovGRBStatus.REVIEW_IN_PROGRESS) && (
+              <RequesterDiscussionsCard
+                systemIntakeId={id}
+                grbMeetingStatus={grbMeetingStatus}
+              />
+            )
+          }
 
           <div className="margin-top-2 display-flex flex-align-center">
             <UswdsReactLink

--- a/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
+++ b/src/features/ITGovernance/Requester/TaskList/GovTaskGrbMeeting/index.tsx
@@ -19,6 +19,8 @@ import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import useMessage from 'hooks/useMessage';
 import { formatDateUtc } from 'utils/date';
 
+import RequesterDiscussionsCard from './_components/RequesterDiscussionsCard';
+
 const GovTaskGrbMeeting = ({
   id,
   itGovTaskStatuses: { grbMeetingStatus },
@@ -282,6 +284,11 @@ const GovTaskGrbMeeting = ({
                 )}
               </>
             )}
+
+          <RequesterDiscussionsCard
+            systemIntakeId={id}
+            grbMeetingStatus={grbMeetingStatus}
+          />
 
           <div className="margin-top-2 display-flex flex-align-center">
             <UswdsReactLink

--- a/src/i18n/en-US/discussions.ts
+++ b/src/i18n/en-US/discussions.ts
@@ -98,7 +98,8 @@ const discussions = {
 
   taskList: {
     noDiscussions: 'There are not yet any discussions for this review.',
-    noDiscussions_COMPLETED: 'There were no discussions during this review.',
+    noDiscussions_AWAITING_DECISION:
+      'There were no discussions during this review.',
     discussionsCount:
       '<0>{{discussionsWithoutRepliesCount}}</0> discussions without replies, <1>{{count}}</1> discussions total'
   }

--- a/src/i18n/en-US/discussions.ts
+++ b/src/i18n/en-US/discussions.ts
@@ -100,7 +100,7 @@ const discussions = {
     noDiscussions: 'There are not yet any discussions for this review.',
     noDiscussions_COMPLETED: 'There were no discussions during this review.',
     discussionsCount:
-      '<strong>{{discussionsWithoutRepliesCount}}</strong> discussions without replies, <strong>{{count}}</strong> discussions total'
+      '<0>{{discussionsWithoutRepliesCount}}</0> discussions without replies, <1>{{count}}</1> discussions total'
   }
 };
 

--- a/src/i18n/en-US/discussions.ts
+++ b/src/i18n/en-US/discussions.ts
@@ -94,6 +94,13 @@ const discussions = {
       // description:
       // 'Use this discussion board to ask questions or have dicussions with the {{groupNames}} members. The conversations here are not visible to the Project team.'
     }
+  },
+
+  taskList: {
+    noDiscussions: 'There are not yet any discussions for this review.',
+    noDiscussions_COMPLETED: 'There were no discussions during this review.',
+    discussionsCount:
+      '<strong>{{discussionsWithoutRepliesCount}}</strong> discussions without replies, <strong>{{count}}</strong> discussions total'
   }
 };
 

--- a/src/tests/mock/discussions.ts
+++ b/src/tests/mock/discussions.ts
@@ -1,8 +1,13 @@
 import {
+  GetSystemIntakeGRBDiscussionsDocument,
+  GetSystemIntakeGRBDiscussionsQuery,
+  GetSystemIntakeGRBDiscussionsQueryVariables,
   SystemIntakeGRBReviewDiscussionFragment,
   SystemIntakeGRBReviewerRole,
   SystemIntakeGRBReviewerVotingRole
 } from 'gql/generated/graphql';
+
+import { MockedQuery } from 'types/util';
 
 import { systemIntake } from './systemIntake';
 import users from './users';
@@ -139,3 +144,37 @@ export const mockDiscussionsWithoutReplies = (
     replies: []
   }
 ];
+
+/** Array of discussions with and without replies */
+const grbDiscussions: SystemIntakeGRBReviewDiscussionFragment[] = [
+  ...mockDiscussions(),
+  ...mockDiscussionsWithoutReplies()
+];
+
+export const getSystemIntakeGRBDiscussionsQuery = (
+  data: {
+    grbDiscussionsPrimary?: SystemIntakeGRBReviewDiscussionFragment[];
+    grbDiscussionsInternal?: SystemIntakeGRBReviewDiscussionFragment[];
+  } = {}
+): MockedQuery<
+  GetSystemIntakeGRBDiscussionsQuery,
+  GetSystemIntakeGRBDiscussionsQueryVariables
+> => ({
+  request: {
+    query: GetSystemIntakeGRBDiscussionsDocument,
+    variables: {
+      id: systemIntake.id
+    }
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      systemIntake: {
+        __typename: 'SystemIntake',
+        id: systemIntake.id,
+        grbDiscussionsInternal: data?.grbDiscussionsInternal || grbDiscussions,
+        grbDiscussionsPrimary: data?.grbDiscussionsPrimary || grbDiscussions
+      }
+    }
+  }
+});

--- a/src/tests/mock/govTaskList.ts
+++ b/src/tests/mock/govTaskList.ts
@@ -896,6 +896,34 @@ export const taskListState: {
       grbReviewAsyncEndDate: '2023-07-20T00:30:28Z'
     }
   },
+  grbMeetingAwaitingDecision: {
+    systemIntake: {
+      ...taskListSystemIntake,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.DONE,
+        grtMeetingStatus: ITGovGRTStatus.COMPLETED,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.DONE,
+        grbMeetingStatus: ITGovGRBStatus.AWAITING_DECISION,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      step: SystemIntakeStep.GRB_MEETING,
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z',
+      grtDate: '2023-07-17T00:30:28Z',
+      grbDate: '2023-07-20T00:30:28Z',
+      businessCase: {
+        __typename: 'BusinessCase',
+        id: '1a4baff0-12ba-4087-8483-678d92b48733'
+      },
+      grbReviewType: SystemIntakeGRBReviewType.STANDARD,
+      grbReviewStartedAt: '2023-07-20T00:30:28Z',
+      grbReviewAsyncGRBMeetingTime: '2023-07-20T00:30:28Z',
+      grbReviewAsyncEndDate: '2023-07-20T00:30:28Z'
+    }
+  },
   grbMeetingDone: {
     systemIntake: {
       ...taskListSystemIntake,


### PR DESCRIPTION
# EASI-4858

[Figma](https://www.figma.com/design/G0UN35V7SY0g9nkTIESxsY/EASi-GRB-Experience?node-id=2763-101981&t=s5adJm96HC1Ba1Pl-0)

## Description
- Updated GRB Review task list step to include requester discussions card
  - Only renders when GRB meeting status is `REVIEW_IN_PROGRESS` or `AWAITING_DECISION`
  - Button functionality to view discussion board and start discussion will be completed in EASI-4857
- Unit tests 


## How to test this change
- Log in locally as `USR1` with `EASI_P_USER` code
- Go to task list of seeded request titled "System Intake with some different GRB Reviewers (and discussions)"
- Verify that the discussions card matches the Figma at different GRB meeting statuses
  - Update [this line](https://github.com/CMS-Enterprise/easi-app/blob/007449fb2008c27832c0d0d68e263f81b3ff198e/src/features/ITGovernance/Requester/TaskList/index.tsx#L215) to mock different GRB meeting statuses. Example:
  ```tsx
  <GovTaskGrbMeeting
    {...systemIntake}
    itGovTaskStatuses={{
       ...systemIntake.itGovTaskStatuses,
       grbMeetingStatus: ITGovGRBStatus.REVIEW_IN_PROGRESS
    }}
  />
  ``` 

## PR Author Checklist

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
