### PR TITLE
[EASI-4860] Enable send reminder button

### DIFF
--- a/pkg/graph/resolvers/system_intake_grb_reviewer.go
+++ b/pkg/graph/resolvers/system_intake_grb_reviewer.go
@@ -430,11 +430,6 @@ func validateCanSendReminder(systemIntake *models.SystemIntake) error {
 		return errors.New("unexpected nil system intake when attempting to send reminder")
 	}
 
-	// prevent sending within 24 hours of last reminder
-	if systemIntake.GrbReviewReminderLastSent != nil && systemIntake.GrbReviewReminderLastSent.After(time.Now().Add(-24*time.Hour)) {
-		return errors.New("previous reminder sent less than 24 hours ago")
-	}
-
 	if systemIntake.GRBReviewStartedAt == nil {
 		return errors.New("grb review not yet started when attempting to send reminder")
 	}

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SystemIntakeGRBReviewerVotingRole } from 'gql/generated/graphql';
+import i18next from 'i18next';
+import { grbReviewers } from 'tests/mock/grbReview';
+import { systemIntake } from 'tests/mock/systemIntake';
+
+import { MessageProvider } from 'hooks/useMessage';
+import { formatDateLocal, formatTimeLocal } from 'utils/date';
+import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
+
+import '@testing-library/jest-dom';
+
+import GRBReviewAdminTask from './index';
+
+describe('GRBReviewAdminTask', () => {
+  describe('Send review reminder', () => {
+    it('renders the task with no previous reminder sent', async () => {
+      render(
+        <MemoryRouter>
+          <VerboseMockedProvider>
+            <MessageProvider>
+              <GRBReviewAdminTask
+                systemIntakeId={systemIntake.id}
+                grbReviewStartedAt="2025-05-08T14:00:39.089005Z"
+                grbReviewReminderLastSent={null}
+                grbReviewers={[]}
+                isITGovAdmin
+              />
+            </MessageProvider>
+          </VerboseMockedProvider>
+        </MemoryRouter>
+      );
+
+      expect(
+        screen.getByRole('heading', { name: 'Send review reminder' })
+      ).toBeInTheDocument();
+
+      expect(screen.queryByTestId('review-reminder')).not.toBeInTheDocument();
+    });
+
+    it('displays the date and time of last reminder sent', async () => {
+      const grbReviewReminderLastSent = '2025-05-09T14:00:39.089005Z';
+
+      render(
+        <MemoryRouter>
+          <VerboseMockedProvider>
+            <MessageProvider>
+              <GRBReviewAdminTask
+                systemIntakeId={systemIntake.id}
+                grbReviewStartedAt="2025-05-08T14:00:39.089005Z"
+                grbReviewReminderLastSent={grbReviewReminderLastSent}
+                grbReviewers={[]}
+                isITGovAdmin
+              />
+            </MessageProvider>
+          </VerboseMockedProvider>
+        </MemoryRouter>
+      );
+
+      expect(
+        screen.getByRole('heading', { name: 'Send review reminder' })
+      ).toBeInTheDocument();
+
+      const previousReminderText = i18next.t<string>(
+        'grbReview:adminTask.sendReviewReminder.mostRecentReminder',
+        {
+          date: formatDateLocal(grbReviewReminderLastSent, 'MM/dd/yyyy'),
+          time: formatTimeLocal(grbReviewReminderLastSent)
+        }
+      );
+
+      expect(screen.getByTestId('review-reminder')).toHaveTextContent(
+        previousReminderText
+      );
+    });
+
+    it('opens the modal with correct number of reviewers', async () => {
+      render(
+        <MemoryRouter>
+          <VerboseMockedProvider>
+            <MessageProvider>
+              <GRBReviewAdminTask
+                systemIntakeId={systemIntake.id}
+                grbReviewStartedAt="2025-05-08T14:00:39.089005Z"
+                grbReviewReminderLastSent="2025-05-09T14:00:39.089005Z"
+                grbReviewers={grbReviewers}
+                isITGovAdmin
+              />
+            </MessageProvider>
+          </VerboseMockedProvider>
+        </MemoryRouter>
+      );
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Send reminder'
+        })
+      );
+
+      /* Check that modal text displays correct number of reviewers */
+
+      const votingReviewers = grbReviewers.filter(
+        reviewer =>
+          reviewer.votingRole === SystemIntakeGRBReviewerVotingRole.VOTING
+      );
+
+      const reviewersNotVoted = votingReviewers.filter(
+        reviewer => !reviewer.vote
+      );
+
+      const modalText = await screen.findByText(
+        `Sending this reminder will send a notification email to the ${reviewersNotVoted.length} out of ${votingReviewers.length} Governance Review Board (GRB) voting members who have not yet added a vote for this request.`,
+        { exact: false }
+      );
+
+      expect(modalText).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
@@ -26,9 +26,6 @@ const GRBReviewAdminTask = ({
 }: IntakeRequestCardProps) => {
   const { t } = useTranslation('grbReview');
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [reminderSent, setReminderSent] = useState(
-    grbReviewReminderLastSent || ''
-  );
 
   const whatDoINeedItems: string[] = t('adminTask.setUpGRBReview.whatDoINeed', {
     returnObjects: true
@@ -46,7 +43,6 @@ const GRBReviewAdminTask = ({
         isOpen={isModalOpen}
         setIsModalOpen={setIsModalOpen}
         systemIntakeId={systemIntakeId}
-        setReminderSent={setReminderSent}
         grbReviewers={grbReviewers}
       />
       {grbReviewStartedAt ? (
@@ -73,10 +69,13 @@ const GRBReviewAdminTask = ({
             className="margin-top-0 margin-bottom-3 text-italic text-base-dark"
             data-testid="review-reminder"
           >
-            {reminderSent
+            {grbReviewReminderLastSent
               ? t('adminTask.sendReviewReminder.mostRecentReminder', {
-                  date: formatDateLocal(reminderSent, 'MM/dd/yyyy'),
-                  time: formatTimeLocal(reminderSent)
+                  date: formatDateLocal(
+                    grbReviewReminderLastSent,
+                    'MM/dd/yyyy'
+                  ),
+                  time: formatTimeLocal(grbReviewReminderLastSent)
                 })
               : ''}
           </p>

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
@@ -65,20 +65,18 @@ const GRBReviewAdminTask = ({
           <p className="margin-top-0 margin-bottom-1">
             {t('adminTask.sendReviewReminder.description')}
           </p>
-          <p
-            className="margin-top-0 margin-bottom-3 text-italic text-base-dark"
-            data-testid="review-reminder"
-          >
-            {grbReviewReminderLastSent
-              ? t('adminTask.sendReviewReminder.mostRecentReminder', {
-                  date: formatDateLocal(
-                    grbReviewReminderLastSent,
-                    'MM/dd/yyyy'
-                  ),
-                  time: formatTimeLocal(grbReviewReminderLastSent)
-                })
-              : ''}
-          </p>
+
+          {grbReviewReminderLastSent && (
+            <p
+              className="margin-top-0 margin-bottom-3 text-italic text-base-dark"
+              data-testid="review-reminder"
+            >
+              {t('adminTask.sendReviewReminder.mostRecentReminder', {
+                date: formatDateLocal(grbReviewReminderLastSent, 'MM/dd/yyyy'),
+                time: formatTimeLocal(grbReviewReminderLastSent)
+              })}
+            </p>
+          )}
         </AdminAction>
       ) : (
         <AdminAction

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
@@ -56,8 +56,7 @@ const GRBReviewAdminTask = ({
           buttons={[
             {
               label: t('adminTask.sendReviewReminder.sendReminder'),
-              onClick: () => setIsModalOpen(true),
-              disabled: !!reminderSent
+              onClick: () => setIsModalOpen(true)
             },
             {
               label: t('adminTask.takeADifferentAction'),

--- a/src/features/ITGovernance/Admin/GRBReview/SendReviewReminder/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/SendReviewReminder/index.tsx
@@ -19,13 +19,11 @@ const SendReviewReminder = ({
   isOpen,
   setIsModalOpen,
   systemIntakeId,
-  setReminderSent,
   grbReviewers
 }: {
   isOpen: boolean;
   setIsModalOpen: (isOpen: boolean) => void;
   systemIntakeId: string;
-  setReminderSent: (reminderSent: string) => void;
   grbReviewers: SystemIntakeGRBReviewFragment['grbVotingInformation']['grbReviewers'];
 }) => {
   const { t } = useTranslation('grbReview');
@@ -45,7 +43,8 @@ const SendReviewReminder = ({
   const [sendReminder] = useSendSystemIntakeGRBReviewerReminderMutation({
     variables: {
       systemIntakeID: systemIntakeId
-    }
+    },
+    refetchQueries: ['GetSystemIntakeGRBReview']
   });
 
   const handleSendReminder = () => {
@@ -53,9 +52,6 @@ const SendReviewReminder = ({
 
     sendReminder()
       .then(response => {
-        setReminderSent(
-          response.data?.sendSystemIntakeGRBReviewerReminder?.timeSent || ''
-        );
         setIsModalOpen(false);
         showMessage(t('adminTask.sendReviewReminder.modal.success'), {
           type: 'success'


### PR DESCRIPTION
# EASI-4860

## Description
- Removed code on frontend that disables "Send reminder" button for 24 hours after reminder is sent
  - Unit tests
- Removed code on backend that prevents users from sending additional reminders for 24 hours

## How to test this change
- Log in as user with `EASI_P_GOVTEAM` job code
- Go to GRB review tab of any seeded request
- Complete GRB review set up form to start review
- Click "Send reminder" button in admin task box
- Confirm that "Send reminder" button is still enabled and "Most recent reminder" text renders with correct date/time
- Click "Send reminder" button to send second reminder
  - Wait at least one minute between reminders so time will update
- Confirm that "Most recent reminder" text reflects new date/time

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
