### PR TITLE
[EASI-4901] Fix async GRB end date countdown

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -149,7 +149,7 @@ describe('formatDaysHoursMinutes', () => {
     const result = formatDaysHoursMinutes(futureDate);
 
     expect(result).toEqual({
-      days: 1,
+      days: 0,
       hours: 3,
       minutes: 15
     });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -151,12 +151,12 @@ export const formatDaysHoursMinutes = (
   const now = DateTime.utc();
 
   // Calculate the difference between the two DateTime objects
-  const diff = now.diff(dateTime, ['days', 'hours', 'minutes']);
+  const diff = dateTime.diff(now, ['days', 'hours', 'minutes']);
 
   // Extract whole number of days, hours, and minutes and make them absolute
-  const days = Math.abs(Math.floor(diff.as('days')));
-  const hours = Math.abs(Math.floor(diff.hours));
-  const minutes = Math.abs(Math.floor(diff.minutes));
+  const days = Math.abs(diff.days);
+  const hours = Math.abs(diff.hours);
+  const minutes = Math.floor(Math.abs(diff.minutes));
 
   return { days, hours, minutes };
 };


### PR DESCRIPTION
# EASI-4901

## Description
- Fixed calculation for time until async GRB end date
- Updated unit test

## How to test this change
- Log in as user with admin job codes
- Go to seeded request titled "grb meeting without date set"
- Complete GRB review form for async review type
- Replace [this code](https://github.com/CMS-Enterprise/easi-app/blob/ba76d54e35a033442b3a2690915be14f5bfc3f4a/src/features/ITGovernance/Admin/GRBReview/GRBReviewStatusCard/index.tsx#L105-L107) with the code below, updated to reflect current date
  - This sets the end date to today at 5pm eastern, and is a workaround for the time issue explained in EASI-4900
```jsx
const { days, hours, minutes } = formatDaysHoursMinutes(
  '2025-06-04T21:00:00.000Z'
);
```
- Confirm that countdown renders correctly (should read 0 days since end date is today)

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
