### PR TITLE
[EASI-4922] Async presentation links card updates

### DIFF
--- a/src/features/ITGovernance/Admin/Actions/ProgressToNewStep.tsx
+++ b/src/features/ITGovernance/Admin/Actions/ProgressToNewStep.tsx
@@ -43,7 +43,13 @@ const MeetingDateField = ({
       shouldUnregister
       disabled={disabled}
       render={({ field: { ref, ...field }, fieldState: { error } }) => (
-        <FormGroup error={!!error} className="margin-left-4 margin-top-1">
+        <FormGroup
+          error={!!error}
+          className="margin-left-4 margin-top-1"
+          // Force re-render and value update when disabled prop changes
+          // TODO: Find a better way to handle clearing the DatePickerFormatted field
+          key={disabled ? 'disabled' : 'enabled'}
+        >
           <Label htmlFor={field.name}>
             {t('progressToNewStep.meetingDate')}
           </Label>

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewStatusCard/index.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewStatusCard/index.test.tsx
@@ -11,6 +11,7 @@ import {
   SystemIntakeStatusAdmin
 } from 'gql/generated/graphql';
 import i18next from 'i18next';
+import { systemIntake } from 'tests/mock/systemIntake';
 import ITGovAdminContext from 'wrappers/ITGovAdminContext/ITGovAdminContext';
 
 import { MessageProvider } from 'hooks/useMessage';
@@ -71,7 +72,10 @@ describe('GRBReviewStatusCard', () => {
           <MessageProvider>
             <ModalProvider>
               <ITGovAdminContext.Provider value={isITGovAdmin}>
-                <GRBReviewStatusCard grbReview={grbReview} />
+                <GRBReviewStatusCard
+                  systemIntakeId={systemIntake.id}
+                  grbReview={grbReview}
+                />
               </ITGovAdminContext.Provider>
             </ModalProvider>
           </MessageProvider>

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewStatusCard/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewStatusCard/index.tsx
@@ -19,18 +19,15 @@ import { useRestartReviewModal } from '../RestartReviewModal/RestartReviewModalC
 import EndGRBAsyncVoting from './EndGRBAsyncVoting';
 import ExtendGRBAsyncReview from './ExtendGRBAsyncReview';
 
-export type GRBReviewStatusCardProps = {
-  grbReview: SystemIntakeGRBReviewFragment;
-  className?: string;
-};
-
 type GRBReviewStatusTagProps = {
+  systemIntakeId: string;
   isITGovAdmin: boolean;
   grbReviewType: SystemIntakeGRBReviewType;
   grbReviewStatus: GRBReviewStatus;
 };
 
 const GRBReviewStatusTag = ({
+  systemIntakeId,
   isITGovAdmin,
   grbReviewType,
   grbReviewStatus
@@ -72,7 +69,7 @@ const GRBReviewStatusTag = ({
 
       {showSetupButton && (
         <IconLink
-          to="grb-review/review-type"
+          to={`/it-governance/${systemIntakeId}/grb-review/review-type`}
           className="margin-left-3"
           icon={<Icon.ArrowForward aria-hidden />}
           iconPosition="after"
@@ -84,7 +81,14 @@ const GRBReviewStatusTag = ({
   );
 };
 
+export type GRBReviewStatusCardProps = {
+  systemIntakeId: string;
+  grbReview: SystemIntakeGRBReviewFragment;
+  className?: string;
+};
+
 const GRBReviewStatusCard = ({
+  systemIntakeId,
   grbReview,
   className
 }: GRBReviewStatusCardProps) => {
@@ -170,6 +174,7 @@ const GRBReviewStatusCard = ({
 
       {/* Status Section */}
       <GRBReviewStatusTag
+        systemIntakeId={systemIntakeId}
         grbReviewType={grbReviewType}
         grbReviewStatus={grbReviewStatus}
         isITGovAdmin={isITGovAdmin}

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.test.tsx
@@ -200,6 +200,8 @@ describe('Async Presentation Links Card', () => {
     });
 
     expect(await screen.findByText(/this review is over/i)).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'restart' })).toBeInTheDocument();
   });
 
   it('renders the review not started variant', () => {
@@ -207,12 +209,12 @@ describe('Async Presentation Links Card', () => {
 
     expect(
       screen.getByText(
-        'You have not completed setup for this asynchronous review. Continue the GRB review setup process to add information about this asynchronous presentation.'
+        'You have not completed setup for this review. Continue the GRB review setup process to add presentation links and/or a slide deck.'
       )
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', { name: 'Set up GRB review' })
+      screen.getByRole('link', { name: 'Continue GRB review setup' })
     ).toBeInTheDocument();
   });
 });

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.test.tsx
@@ -4,7 +4,8 @@ import { MockedProvider } from '@apollo/client/testing';
 import { render, screen } from '@testing-library/react';
 import {
   SystemIntakeDocumentStatus,
-  SystemIntakeGRBReviewAsyncStatusType
+  SystemIntakeGRBReviewAsyncStatusType,
+  SystemIntakeGRBReviewType
 } from 'gql/generated/graphql';
 import { grbPresentationLinks, systemIntake } from 'tests/mock/systemIntake';
 
@@ -23,7 +24,10 @@ describe('Async Presentation Links Card', () => {
     props: Partial<ComponentProps<typeof PresentationLinksCard>>,
     isAdmin: boolean = true
   ) {
-    const { grbReviewStartedAt = '2025-04-04T19:56:57.994482Z' } = props;
+    const {
+      grbReviewStartedAt = '2025-04-04T19:56:57.994482Z',
+      grbReviewType = SystemIntakeGRBReviewType.ASYNC
+    } = props;
 
     return render(
       <MemoryRouter
@@ -35,6 +39,7 @@ describe('Async Presentation Links Card', () => {
               <ITGovAdminContext.Provider value={isAdmin}>
                 <PresentationLinksCard
                   systemIntakeID={systemIntake.id}
+                  grbReviewType={grbReviewType}
                   grbPresentationLinks={props.grbPresentationLinks}
                   asyncStatus={props.asyncStatus}
                   grbReviewStartedAt={grbReviewStartedAt}
@@ -92,7 +97,9 @@ describe('Async Presentation Links Card', () => {
       }
     });
 
-    screen.queryByText('Virus scanning in progress...');
+    expect(
+      screen.getByText('Virus scanning in progress...')
+    ).toBeInTheDocument();
   });
 
   it('hides empty fields', () => {
@@ -174,6 +181,16 @@ describe('Async Presentation Links Card', () => {
     });
 
     screen.getByText('Asynchronous presentation not scheduled yet');
+  });
+
+  it('hides presentation date text for standard meetings', () => {
+    renderCard({
+      grbReviewType: SystemIntakeGRBReviewType.STANDARD
+    });
+
+    expect(
+      screen.queryByText('Asynchronous presentation not scheduled yet')
+    ).not.toBeInTheDocument();
   });
 
   it('renders the Complete Async Status variant', async () => {

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
@@ -95,7 +95,7 @@ const PresentationCardActions = ({
           {t('asyncPresentation.adminEmptyAlert')}
         </Alert>
         <IconLink
-          icon={<Icon.Add />}
+          icon={<Icon.Add aria-hidden />}
           to={`/it-governance/${systemIntakeID}/grb-review/presentation-links`}
         >
           {t('asyncPresentation.addAsynchronousPresentationLinks')}

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
@@ -24,6 +24,7 @@ import IconLink from 'components/IconLink';
 import UswdsReactLink from 'components/LinkWrapper';
 import Modal from 'components/Modal';
 import useMessage from 'hooks/useMessage';
+import { formatDateLocal } from 'utils/date';
 import { downloadFileFromURL } from 'utils/downloadFile';
 
 import ITGovAdminContext from '../../../../../wrappers/ITGovAdminContext/ITGovAdminContext';
@@ -126,13 +127,15 @@ export type PresentationLinksCardProps = {
   grbReviewStartedAt?: string | null;
   grbPresentationLinks?: SystemIntakeGRBPresentationLinksFragmentFragment | null;
   asyncStatus?: SystemIntakeGRBReviewAsyncStatusType | null;
+  grbReviewAsyncRecordingTime?: string | null;
 };
 
 function PresentationLinksCard({
   systemIntakeID,
   grbReviewStartedAt,
   grbPresentationLinks,
-  asyncStatus
+  asyncStatus,
+  grbReviewAsyncRecordingTime
 }: PresentationLinksCardProps) {
   const { t } = useTranslation('grbReview');
 
@@ -205,7 +208,19 @@ function PresentationLinksCard({
         className="margin-top-2"
       >
         <CardHeader>
-          <h3>{t('asyncPresentation.title')}</h3>
+          <h3 className="margin-y-0 margin-right-2 display-inline-block">
+            {t('asyncPresentation.title')}
+          </h3>
+          <span className="text-base">
+            {t(
+              grbReviewAsyncRecordingTime
+                ? 'asyncPresentation.asyncPresentationDate'
+                : 'asyncPresentation.asyncPresentationNotScheduled',
+              {
+                date: formatDateLocal(grbReviewAsyncRecordingTime, 'MM/dd/yyyy')
+              }
+            )}
+          </span>
         </CardHeader>
         {/* Render action links for admins only */}
         {isITGovAdmin && (

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
@@ -15,6 +15,7 @@ import {
   SystemIntakeDocumentStatus,
   SystemIntakeGRBPresentationLinksFragmentFragment,
   SystemIntakeGRBReviewAsyncStatusType,
+  SystemIntakeGRBReviewType,
   useDeleteSystemIntakeGRBPresentationLinksMutation
 } from 'gql/generated/graphql';
 
@@ -124,6 +125,7 @@ const PresentationCardActions = ({
 
 export type PresentationLinksCardProps = {
   systemIntakeID: string;
+  grbReviewType: SystemIntakeGRBReviewType | undefined;
   grbReviewStartedAt: string | null | undefined;
   asyncStatus: SystemIntakeGRBReviewAsyncStatusType | null | undefined;
   grbReviewAsyncRecordingTime: string | null | undefined;
@@ -135,6 +137,7 @@ export type PresentationLinksCardProps = {
 
 function PresentationLinksCard({
   systemIntakeID,
+  grbReviewType,
   grbReviewStartedAt,
   grbPresentationLinks,
   asyncStatus,
@@ -214,16 +217,21 @@ function PresentationLinksCard({
           <h3 className="margin-y-0 margin-right-2 display-inline-block">
             {t('asyncPresentation.title')}
           </h3>
-          <span className="text-base">
-            {t(
-              grbReviewAsyncRecordingTime
-                ? 'asyncPresentation.asyncPresentationDate'
-                : 'asyncPresentation.asyncPresentationNotScheduled',
-              {
-                date: formatDateLocal(grbReviewAsyncRecordingTime, 'MM/dd/yyyy')
-              }
-            )}
-          </span>
+          {grbReviewType === SystemIntakeGRBReviewType.ASYNC && (
+            <span className="text-base">
+              {t(
+                grbReviewAsyncRecordingTime
+                  ? 'asyncPresentation.asyncPresentationDate'
+                  : 'asyncPresentation.asyncPresentationNotScheduled',
+                {
+                  date: formatDateLocal(
+                    grbReviewAsyncRecordingTime,
+                    'MM/dd/yyyy'
+                  )
+                }
+              )}
+            </span>
+          )}
         </CardHeader>
         {/* Render action links for admins only */}
         {isITGovAdmin && (

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
@@ -65,7 +65,7 @@ const PresentationCardActions = ({
           to={`/it-governance/${systemIntakeID}/grb-review/review-type`}
           iconPosition="after"
         >
-          {t('adminTask.setUpGRBReview.title')}
+          {t('asyncPresentation.continueReviewSetup')}
         </IconLink>
       </>
     );

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksCard/PresentationLinksCard.tsx
@@ -35,7 +35,7 @@ export type PresentationCardActionsProps = {
   hasAnyLinks: boolean;
   setRemovePresentationLinksModalOpen: (open: boolean) => void;
   grbReviewStartedAt: string | null | undefined;
-  asyncStatus?: SystemIntakeGRBReviewAsyncStatusType | null;
+  asyncStatus: SystemIntakeGRBReviewAsyncStatusType | null | undefined;
 };
 
 /**
@@ -124,10 +124,13 @@ const PresentationCardActions = ({
 
 export type PresentationLinksCardProps = {
   systemIntakeID: string;
-  grbReviewStartedAt?: string | null;
-  grbPresentationLinks?: SystemIntakeGRBPresentationLinksFragmentFragment | null;
-  asyncStatus?: SystemIntakeGRBReviewAsyncStatusType | null;
-  grbReviewAsyncRecordingTime?: string | null;
+  grbReviewStartedAt: string | null | undefined;
+  asyncStatus: SystemIntakeGRBReviewAsyncStatusType | null | undefined;
+  grbReviewAsyncRecordingTime: string | null | undefined;
+  grbPresentationLinks:
+    | SystemIntakeGRBPresentationLinksFragmentFragment
+    | null
+    | undefined;
 };
 
 function PresentationLinksCard({

--- a/src/features/ITGovernance/Admin/GRBReview/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/index.tsx
@@ -155,7 +155,7 @@ const GRBReview = ({ systemIntake, businessCase }: GRBReviewProps) => {
           {t('reviewDetails.text')}
         </p>
         {/* GRB Review Status */}
-        <GRBReviewStatusCard grbReview={grbReview} />
+        <GRBReviewStatusCard systemIntakeId={id} grbReview={grbReview} />
         {/* Decision Record */}
         <DecisionRecordCard
           grbVotingInformation={grbReview.grbVotingInformation}

--- a/src/features/ITGovernance/Admin/GRBReview/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/index.tsx
@@ -80,7 +80,8 @@ const GRBReview = ({ systemIntake, businessCase }: GRBReviewProps) => {
     grbReviewType,
     grbReviewStartedAt,
     grbReviewAsyncStatus,
-    grbReviewStandardStatus
+    grbReviewStandardStatus,
+    grbReviewAsyncRecordingTime
   } = grbReview || {};
 
   const { euaId } = useSelector((appState: AppState) => appState.auth);
@@ -201,6 +202,7 @@ const GRBReview = ({ systemIntake, businessCase }: GRBReviewProps) => {
           grbReviewStartedAt={grbReviewStartedAt}
           grbPresentationLinks={grbReview.grbPresentationLinks}
           asyncStatus={grbReviewAsyncStatus}
+          grbReviewAsyncRecordingTime={grbReviewAsyncRecordingTime}
         />
         {/* Business Case Card */}
         <BusinessCaseCard businessCase={businessCase} systemIntakeID={id} />

--- a/src/features/ITGovernance/Admin/GRBReview/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/index.tsx
@@ -199,6 +199,7 @@ const GRBReview = ({ systemIntake, businessCase }: GRBReviewProps) => {
         {/* Presentation Links */}
         <PresentationLinksCard
           systemIntakeID={id}
+          grbReviewType={grbReviewType}
           grbReviewStartedAt={grbReviewStartedAt}
           grbPresentationLinks={grbReview.grbPresentationLinks}
           asyncStatus={grbReviewAsyncStatus}

--- a/src/i18n/en-US/grbReview.ts
+++ b/src/i18n/en-US/grbReview.ts
@@ -136,6 +136,9 @@ export default {
   },
   asyncPresentation: {
     title: 'Asynchronous presentation',
+    asyncPresentationDate: 'Asynchronous presentation: {{date}}',
+    asyncPresentationNotScheduled:
+      'Asynchronous presentation not scheduled yet',
     editPresentationLinks: 'Edit presentation links',
     removeAllPresentationLinks: 'Remove all presentation links',
     viewRecording: 'View recording',

--- a/src/i18n/en-US/grbReview.ts
+++ b/src/i18n/en-US/grbReview.ts
@@ -128,14 +128,14 @@ export default {
     'The documents below will help the GRB review this IT Governance request, and were completed during the course of this IT Governance request or were added by the requester and/or the Governance Admin Team. You may add additional documents and may remove any that have been added by Governance Admin Team members.',
   asyncCompleted: {
     presentationLinks:
-      'This review is over. Please <link1>restart</link1> it if you would like to update presentation links.',
+      'This review is over. For an asynchronous review, you may <link1>restart</link1> to update presentation links.',
     documents:
       'This review is over. Please <link1>restart</link1> it if you would like to add additional documents.',
     reviewers:
       'This review is over. Please <link1>restart</link1> it to add additional reviewers.'
   },
   asyncPresentation: {
-    title: 'Asynchronous presentation',
+    title: 'Presentation links',
     asyncPresentationDate: 'Asynchronous presentation: {{date}}',
     asyncPresentationNotScheduled:
       'Asynchronous presentation not scheduled yet',
@@ -150,8 +150,9 @@ export default {
     virusScanning: 'Virus scanning in progress...',
     adminEmptyAlert:
       'If this GRB review has an asynchronous presentation and recording, you may add that content to EASi to provide additional information for GRB reviews.',
+    continueReviewSetup: 'Continue GRB review setup',
     reviewSetupNotCompleted:
-      'You have not completed setup for this asynchronous review. Continue the GRB review setup process to add information about this asynchronous presentation.',
+      'You have not completed setup for this review. Continue the GRB review setup process to add presentation links and/or a slide deck.',
     emptyAlert: 'The GRB have not yet added presentation links.',
 
     modalRemoveLinks: {


### PR DESCRIPTION
# EASI-4922

[Figma](https://www.figma.com/design/jo2KOvJWY4YDSYfmfW3adR/EASi-System-Library?node-id=2931-594&t=cYTTW1uDdIgAmN4i-1)

## Description
- Added async presentation date to card header
  - Hidden for standard meetings
-  Text updates to match Figma
- [QA doc #10](https://docs.google.com/document/d/1r5vLwLEwFG94PKviSUzw1TT_HiNqzR8nTwfkkeImmFc/edit?tab=t.0#heading=h.9k0w4spkfgra) - fixed broken "Set up review" link

> [!IMPORTANT]  
> This does NOT include changes to add the async presentation recording date field to the add/edit presentation links form. Those changes will be in a separate PR.

## How to test this change
- Log in as user with admin job code
- Go to GRB review tab of request "GRB meeting without date set"
    - Testing steps below are to check presentation date. Confirm that card matches Figma for different states.
- Presentation links card should not show presentation date text next to header (review type is Standard)
- In GRB review set up form, change review type to async
- Click "Save and return to request"
- Presentation links card should show "Asynchronous presentation not scheduled yet" text
- In GRB review set up form, fill asynchronous presentation recording date field and complete form
- Presentation links card should show "Asynchronous presentation: mm/dd/yyy" text

## PR Author Checklist
- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
