### PR TITLE
[EASI-4922] Presentation links form updates

### DIFF
--- a/src/features/ITGovernance/Admin/Actions/ProgressToNewStep.tsx
+++ b/src/features/ITGovernance/Admin/Actions/ProgressToNewStep.tsx
@@ -43,7 +43,13 @@ const MeetingDateField = ({
       shouldUnregister
       disabled={disabled}
       render={({ field: { ref, ...field }, fieldState: { error } }) => (
-        <FormGroup error={!!error} className="margin-left-4 margin-top-1">
+        <FormGroup
+          error={!!error}
+          className="margin-left-4 margin-top-1"
+          // Force re-render and value update when disabled prop changes
+          // TODO: Find a better way to handle clearing the DatePickerFormatted field
+          key={disabled ? 'disabled' : 'enabled'}
+        >
           <Label htmlFor={field.name}>
             {t('progressToNewStep.meetingDate')}
           </Label>

--- a/src/features/ITGovernance/Admin/GRBReview/PresentationLinksForm/index.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/PresentationLinksForm/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
-import { SystemIntakeGRBPresentationLinks } from 'gql/generated/graphql';
-import { systemIntake } from 'tests/mock/systemIntake';
+import { SystemIntakeGRBReviewType } from 'gql/generated/graphql';
+import { grbPresentationLinks, systemIntake } from 'tests/mock/systemIntake';
 
 import { MessageProvider } from 'hooks/useMessage';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
@@ -16,10 +16,10 @@ describe('GRB presentation links form', () => {
         <VerboseMockedProvider>
           <MessageProvider>
             <PresentationLinksForm
-              {...systemIntake}
-              grbPresentationLinks={
-                undefined as unknown as SystemIntakeGRBPresentationLinks
-              }
+              id={systemIntake.id}
+              grbReviewType={SystemIntakeGRBReviewType.ASYNC}
+              grbPresentationLinks={null}
+              grbReviewAsyncRecordingTime={null}
             />
           </MessageProvider>
         </VerboseMockedProvider>
@@ -54,13 +54,10 @@ describe('GRB presentation links form', () => {
         <VerboseMockedProvider>
           <MessageProvider>
             <PresentationLinksForm
-              {...systemIntake}
-              grbPresentationLinks={
-                {
-                  recordingLink: 'http://google.com',
-                  presentationDeckFileName: 'test.pdf'
-                } as SystemIntakeGRBPresentationLinks
-              }
+              id={systemIntake.id}
+              grbReviewType={SystemIntakeGRBReviewType.ASYNC}
+              grbPresentationLinks={grbPresentationLinks}
+              grbReviewAsyncRecordingTime="2025-07-10T12:00:00Z"
             />
           </MessageProvider>
         </VerboseMockedProvider>
@@ -68,7 +65,7 @@ describe('GRB presentation links form', () => {
     );
 
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Edit presentation link' })
+      screen.getByRole('heading', { level: 1, name: 'Edit presentation links' })
     ).toBeInTheDocument();
 
     expect(
@@ -84,14 +81,43 @@ describe('GRB presentation links form', () => {
     ).toHaveLength(2);
 
     expect(screen.getByRole('textbox', { name: 'Recording link' })).toHaveValue(
-      'http://google.com'
+      'https://google.com'
     );
 
-    expect(screen.getByText('test.pdf')).toBeInTheDocument();
+    expect(screen.getByText('presentationDeck.pptx')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('textbox', {
+        name: 'Asynchronous presentation recording date'
+      })
+    ).toHaveValue('07/10/2025');
 
     // Button should be disabled before any changes are made
     expect(
       screen.getByRole('button', { name: 'Save presentation details' })
     ).toBeDisabled();
+  });
+
+  it('hides the async presentation recording date field for standard meetings', () => {
+    render(
+      <MemoryRouter>
+        <VerboseMockedProvider>
+          <MessageProvider>
+            <PresentationLinksForm
+              id={systemIntake.id}
+              grbReviewType={SystemIntakeGRBReviewType.STANDARD}
+              grbPresentationLinks={grbPresentationLinks}
+              grbReviewAsyncRecordingTime={null}
+            />
+          </MessageProvider>
+        </VerboseMockedProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.queryByRole('textbox', {
+        name: 'Asynchronous presentation recording date'
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/ITGovernance/Admin/RequestOverview/RequestOverview.tsx
+++ b/src/features/ITGovernance/Admin/RequestOverview/RequestOverview.tsx
@@ -5,12 +5,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useParams } from 'react-router-dom';
 import classnames from 'classnames';
 import DocumentUploadForm from 'features/ITGovernance/_components/DocumentUploadForm';
-import PresentationLinksForm from 'features/ITGovernance/Admin/GRBReview/PresentationLinksForm';
 import PresentationDeckUpload from 'features/ITGovernance/Requester/TaskList/PresentationDeckUpload';
 import AdditionalInformation from 'features/Miscellaneous/AdditionalInformation';
 import NotFound from 'features/Miscellaneous/NotFound';
 import {
-  SystemIntakeGRBPresentationLinks,
   SystemIntakeStatusAdmin,
   useGetSystemIntakeQuery
 } from 'gql/generated/graphql';
@@ -210,20 +208,6 @@ const RequestOverview = () => {
                   path="/it-governance/:systemId/lcid"
                   render={() => <LifecycleID systemIntake={systemIntake} />}
                 />
-
-                {flags?.grbReviewTab && (
-                  <Route
-                    path="/it-governance/:systemId/grb-review/presentation-links"
-                    render={() => (
-                      <PresentationLinksForm
-                        {...systemIntake}
-                        grbPresentationLinks={
-                          systemIntake.grbPresentationLinks as SystemIntakeGRBPresentationLinks
-                        }
-                      />
-                    )}
-                  />
-                )}
 
                 {flags?.grbReviewTab && (
                   <Route

--- a/src/features/ITGovernance/Admin/index.tsx
+++ b/src/features/ITGovernance/Admin/index.tsx
@@ -14,6 +14,7 @@ import user from 'utils/user';
 import DecisionRecord from './GRBReview/DecisionRecord';
 import GRBReviewerForm from './GRBReview/GRBReviewerForm';
 import GRBReviewForm from './GRBReview/GRBReviewForm';
+import PresentationLinksForm from './GRBReview/PresentationLinksForm';
 import RequestOverview from './RequestOverview/RequestOverview';
 
 const GovernanceReviewTeam = () => {
@@ -90,6 +91,22 @@ const GovernanceReviewTeam = () => {
                   grbReviewers={grbReview.grbVotingInformation.grbReviewers}
                 />
               </Route>
+            )}
+
+            {flags?.grbReviewTab && (
+              <Route
+                path="/it-governance/:systemId/grb-review/presentation-links"
+                render={() => (
+                  <PresentationLinksForm
+                    id={id}
+                    grbReviewType={grbReview.grbReviewType}
+                    grbPresentationLinks={grbReview.grbPresentationLinks}
+                    grbReviewAsyncRecordingTime={
+                      grbReview.grbReviewAsyncRecordingTime
+                    }
+                  />
+                )}
+              />
             )}
 
             <Route

--- a/src/i18n/en-US/grbReview.ts
+++ b/src/i18n/en-US/grbReview.ts
@@ -437,7 +437,7 @@ export default {
   },
   presentationLinks: {
     heading_add: 'Add presentation links',
-    heading_edit: 'Edit presentation link',
+    heading_edit: 'Edit presentation links',
     description_add:
       'If this GRB review has an asynchronous presentation and recording, add that content in the fields below to provide additional information for GRB reviews.',
     description_edit:

--- a/src/validations/grbReviewSchema.ts
+++ b/src/validations/grbReviewSchema.ts
@@ -102,9 +102,9 @@ export const SetGRBPresentationLinksSchema = Yup.object().shape(
     }),
 
     // Optional fields
-    recordingPasscode: Yup.string(),
+    recordingPasscode: Yup.string().nullable(),
     transcriptFileData: Yup.mixed(),
-    transcriptLink: Yup.string()
+    transcriptLink: Yup.string().nullable()
   },
   // Prevents cyclic dependency error
   [['recordingLink', 'presentationDeckFileData']]


### PR DESCRIPTION
# EASI-4922

## Description
- Added async presentation recording date field to add/edit presentation links form
  - Updated to match page in set up GRB review form (dividers, subheaders, etc)
- Unit tests


## How to test this change
- Log in as user with admin job code
- Go to GRB review tab of request "Async GRB review (with discussions)"
- Click "Edit presentation links" button in presentation links card
- Fill async presentation recording date field
- Submit form
- Click "Edit presentation links" button
- Field should display default value
- Go to GRB review tab of request "GRB meeting scheduled"
- Click "Add asynchronous presentation links" button
- Async presentation recording date field should be hidden
- Fill and submit form

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
