### PR TITLE
[NOREF] GRB review modal error fix

### DIFF
--- a/src/components/AdminAction/index.tsx
+++ b/src/components/AdminAction/index.tsx
@@ -28,6 +28,7 @@ type AdminActionProps = {
   description?: string;
   children?: React.ReactNode;
   className?: string;
+  'data-testid'?: string;
 };
 
 /**
@@ -39,13 +40,17 @@ const AdminAction = ({
   description,
   children,
   buttons,
-  className
+  className,
+  'data-testid': testId
 }: AdminActionProps) => {
   const { t } = useTranslation('technicalAssistance');
   const { t: grbReviewT } = useTranslation('grbReview');
 
   return (
-    <div className={classNames('usa-summary-box', className)}>
+    <div
+      className={classNames('usa-summary-box', className)}
+      data-testid={testId}
+    >
       <h5 className="text-base-dark text-uppercase margin-top-0 margin-bottom-05 line-height-body-1 text-normal text-body-xs">
         {type === 'TRB'
           ? t('adminAction.title')

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.test.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.test.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SystemIntakeGRBReviewerVotingRole } from 'gql/generated/graphql';
+import {
+  SendSystemIntakeGRBReviewerReminderDocument,
+  SendSystemIntakeGRBReviewerReminderMutation,
+  SystemIntakeGRBReviewerVotingRole
+} from 'gql/generated/graphql';
 import i18next from 'i18next';
 import { grbReviewers } from 'tests/mock/grbReview';
 import { systemIntake } from 'tests/mock/systemIntake';
 
 import { MessageProvider } from 'hooks/useMessage';
+import { MockedQuery } from 'types/util';
 import { formatDateLocal, formatTimeLocal } from 'utils/date';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
@@ -117,6 +122,75 @@ describe('GRBReviewAdminTask', () => {
       );
 
       expect(modalText).toBeInTheDocument();
+    });
+
+    it('clears error message on modal close', async () => {
+      const sendReminderMutation: MockedQuery<SendSystemIntakeGRBReviewerReminderMutation> =
+        {
+          request: {
+            query: SendSystemIntakeGRBReviewerReminderDocument,
+            variables: {
+              systemIntakeID: systemIntake.id
+            }
+          },
+          error: new Error()
+        };
+
+      render(
+        <MemoryRouter>
+          <VerboseMockedProvider mocks={[sendReminderMutation]}>
+            <MessageProvider>
+              <GRBReviewAdminTask
+                systemIntakeId={systemIntake.id}
+                grbReviewStartedAt="2025-05-08T14:00:39.089005Z"
+                grbReviewReminderLastSent={null}
+                grbReviewers={[]}
+                isITGovAdmin
+              />
+            </MessageProvider>
+          </VerboseMockedProvider>
+        </MemoryRouter>
+      );
+
+      const adminAction = screen.getByTestId('grb-review-admin-task');
+
+      const openModalButton = within(adminAction).getByRole('button', {
+        name: 'Send reminder'
+      });
+
+      // Open send remindermodal
+
+      userEvent.click(openModalButton);
+
+      const modal = await screen.findByRole('dialog');
+
+      const sendReminderButton = within(modal).getByRole('button', {
+        name: 'Send reminder'
+      });
+
+      // Check that clicking the send reminder button shows an error message
+
+      userEvent.click(sendReminderButton);
+
+      expect(await screen.findByTestId('alert')).toHaveTextContent(
+        'There was an issue sending your reminder.'
+      );
+
+      // Close modal
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Go back without sending' })
+      );
+
+      expect(modal).not.toBeInTheDocument();
+
+      // Open modal and check that error message has been cleared
+
+      userEvent.click(openModalButton);
+
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+      expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/GRBReviewAdminTask/index.tsx
@@ -48,6 +48,7 @@ const GRBReviewAdminTask = ({
       {grbReviewStartedAt ? (
         <AdminAction
           type="ITGov"
+          data-testid="grb-review-admin-task"
           title={t('adminTask.sendReviewReminder.title')}
           buttons={[
             {

--- a/src/features/ITGovernance/Admin/GRBReview/RestartReviewModal/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/RestartReviewModal/index.tsx
@@ -37,6 +37,11 @@ const RestartReviewModal = ({ systemIntakeId }: { systemIntakeId: string }) => {
     refetchQueries: [GetSystemIntakeGRBReviewDocument, GetSystemIntakeDocument]
   });
 
+  const handleCloseModal = () => {
+    closeModal();
+    showErrorMessageInModal('');
+  };
+
   const handleSubmit: ReactEventHandler = event => {
     event.preventDefault();
     restartReview({
@@ -60,7 +65,7 @@ const RestartReviewModal = ({ systemIntakeId }: { systemIntakeId: string }) => {
         );
 
         // Close modal on success
-        closeModal();
+        handleCloseModal();
       })
       .catch(() => {
         showErrorMessageInModal(t('adminTask.restartReview.error'));
@@ -71,7 +76,7 @@ const RestartReviewModal = ({ systemIntakeId }: { systemIntakeId: string }) => {
     <Modal
       isOpen={isOpen}
       shouldCloseOnOverlayClick
-      closeModal={closeModal}
+      closeModal={handleCloseModal}
       className="easi-modal__content--narrow"
     >
       <div data-testid="restart-review-modal">
@@ -120,7 +125,7 @@ const RestartReviewModal = ({ systemIntakeId }: { systemIntakeId: string }) => {
             >
               {t('adminTask.restartReview.restart')}
             </Button>
-            <Button type="button" onClick={closeModal} unstyled>
+            <Button type="button" onClick={handleCloseModal} unstyled>
               {t('adminTask.restartReview.cancel')}
             </Button>
           </ModalFooter>

--- a/src/features/ITGovernance/Admin/GRBReview/SendReviewReminder/index.tsx
+++ b/src/features/ITGovernance/Admin/GRBReview/SendReviewReminder/index.tsx
@@ -47,6 +47,11 @@ const SendReviewReminder = ({
     refetchQueries: ['GetSystemIntakeGRBReview']
   });
 
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    showErrorMessageInModal('');
+  };
+
   const handleSendReminder = () => {
     if (!systemIntakeId) return;
 
@@ -66,7 +71,7 @@ const SendReviewReminder = ({
     <Modal
       isOpen={isOpen}
       shouldCloseOnOverlayClick
-      closeModal={() => setIsModalOpen(false)}
+      closeModal={handleCloseModal}
       className="easi-modal__content--narrow"
     >
       <div data-testid="send-review-reminder-modal">
@@ -92,7 +97,7 @@ const SendReviewReminder = ({
           >
             {t('adminTask.sendReviewReminder.modal.sendReminder')}
           </Button>
-          <Button type="button" onClick={() => setIsModalOpen(false)} unstyled>
+          <Button type="button" onClick={handleCloseModal} unstyled>
             {t('adminTask.sendReviewReminder.modal.cancel')}
           </Button>
         </ModalFooter>


### PR DESCRIPTION
# NOREF

## Description
[Fixes QA item #13](https://docs.google.com/document/d/1r5vLwLEwFG94PKviSUzw1TT_HiNqzR8nTwfkkeImmFc/edit?tab=t.0#heading=h.gi1tgeo2o47m)
- Added code to clear error message on modal close
- Unit test to check that error message is cleared


## How to test this change
- Log in as user with admin job code
- Go to GRB review tab of request "Async GRB review (voting complete)"
- Click "Restart review" button and submit form to restart voting
- Click "Send reminder" button and submit modal
- Error message should display in modal
- Close modal
- Click "Send reminder" button again to check that modal error message was cleared
- Close modal
- Click "End voting" button and submit modal to end review
- Click "Restart review" button
- Error message should not display in modal

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
