### PR TITLE
[EASI-4963] Add OTHER to SystemIntakeRequestType

### DIFF
--- a/migrations/V217__Add_Other_Intake_Request_Type.sql
+++ b/migrations/V217__Add_Other_Intake_Request_Type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE intake_request_type ADD VALUE 'OTHER';

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -9365,6 +9365,7 @@ enum SystemIntakeRequestType {
   NEW
   RECOMPETE
   SHUTDOWN
+  OTHER
 }
 
 """

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -576,6 +576,7 @@ enum SystemIntakeRequestType {
   NEW
   RECOMPETE
   SHUTDOWN
+  OTHER
 }
 
 """

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -23,6 +23,8 @@ const (
 	SystemIntakeRequestTypeRECOMPETE SystemIntakeRequestType = "RECOMPETE"
 	// SystemIntakeRequestTypeSHUTDOWN captures enum value of "SHUTDOWN"
 	SystemIntakeRequestTypeSHUTDOWN SystemIntakeRequestType = "SHUTDOWN"
+	// SystemIntakeRequestTypeSHUTDOWN captures enum value of "OTHER"
+	SystemIntakeRequestTypeOTHER SystemIntakeRequestType = "OTHER"
 )
 
 // SystemIntakeState represents whether the intake is open or closed

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -2753,6 +2753,7 @@ export type SystemIntakeRequestEditsInput = {
 export enum SystemIntakeRequestType {
   MAJOR_CHANGES = 'MAJOR_CHANGES',
   NEW = 'NEW',
+  OTHER = 'OTHER',
   RECOMPETE = 'RECOMPETE',
   SHUTDOWN = 'SHUTDOWN'
 }

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -186,7 +186,8 @@ const intake = {
     new: 'Add a new system or service',
     recompete: 'Re-compete',
     majorChanges: 'Major change or upgrade',
-    shutdown: 'Decommission a system'
+    shutdown: 'Decommission a system',
+    other: 'Other'
   },
 
   csvHeadings: {

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -11,7 +11,12 @@ import cmsGovernanceTeams from 'constants/enums/cmsGovernanceTeams';
 import SystemIntakeContractStatus from 'constants/enums/SystemIntakeContractStatus';
 import SystemIntakeSoftwareAcquisitionMethods from 'constants/enums/SystemIntakeSoftwareAcquisitionMethods';
 
-export type RequestType = 'NEW' | 'MAJOR_CHANGES' | 'RECOMPETE' | 'SHUTDOWN';
+export type RequestType =
+  | 'NEW'
+  | 'MAJOR_CHANGES'
+  | 'RECOMPETE'
+  | 'SHUTDOWN'
+  | 'OTHER';
 
 /**
  * Type for SystemIntakeForm


### PR DESCRIPTION
# EASI-4963

## Description
- Backend work to add `OTHER` to the `SystemIntakeRequestType` enum


## How to test this change
1.  Review code changes

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [BRUNO Collection](query_examples/EASi) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
