### PR TITLE
[EASI-4966] System intake spending fields bug fixes

### DIFF
--- a/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.test.tsx
+++ b/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.test.tsx
@@ -9,42 +9,55 @@ describe('SystemIntakeAnnualCosts', () => {
     it('renders the formatted annual spending data', () => {
       const annualSpending: SystemIntakeFragmentFragment['annualSpending'] = {
         __typename: 'SystemIntakeAnnualSpending',
-        currentAnnualSpending: '1000',
-        currentAnnualSpendingITPortion: '50',
-        plannedYearOneSpending: '2000',
-        plannedYearOneSpendingITPortion: '60'
+        currentAnnualSpending: '3.50',
+        currentAnnualSpendingITPortion: '35',
+        plannedYearOneSpending: '123456',
+        plannedYearOneSpendingITPortion: '50'
       };
 
       render(
         <SystemIntakeAnnualCosts annualSpending={annualSpending} costs={null} />
       );
 
-      expect(screen.getByText('$1000')).toBeInTheDocument();
+      expect(screen.getByText('$3.5')).toBeInTheDocument();
+      expect(screen.getByText('35%')).toBeInTheDocument();
+      expect(screen.getByText('$123,456')).toBeInTheDocument();
       expect(screen.getByText('50%')).toBeInTheDocument();
-      expect(screen.getByText('$2000')).toBeInTheDocument();
-      expect(screen.getByText('60%')).toBeInTheDocument();
     });
 
-    it('renders annual spending data when not a number (legacy data)');
-    const legacyAnnualSpending: SystemIntakeFragmentFragment['annualSpending'] =
-      {
-        __typename: 'SystemIntakeAnnualSpending',
-        currentAnnualSpending: 'Kind of a lot',
-        currentAnnualSpendingITPortion: 'A big percentage',
-        plannedYearOneSpending: 'Less than a million',
-        plannedYearOneSpendingITPortion: 'A small percentage'
+    it('renders annual spending data when not a number (legacy data)', () => {
+      const legacyAnnualSpending: SystemIntakeFragmentFragment['annualSpending'] =
+        {
+          __typename: 'SystemIntakeAnnualSpending',
+          currentAnnualSpending: 'Kind of a lot',
+          currentAnnualSpendingITPortion: 'A big percentage',
+          plannedYearOneSpending: 'Less than a million',
+          plannedYearOneSpendingITPortion: 'A small percentage'
+        };
+
+      render(
+        <SystemIntakeAnnualCosts
+          annualSpending={legacyAnnualSpending}
+          costs={null}
+        />
+      );
+
+      expect(screen.getByText('Kind of a lot')).toBeInTheDocument();
+      expect(screen.getByText('A big percentage')).toBeInTheDocument();
+      expect(screen.getByText('Less than a million')).toBeInTheDocument();
+      expect(screen.getByText('A small percentage')).toBeInTheDocument();
+    });
+
+    it('renders increased cost data', () => {
+      const costs: SystemIntakeFragmentFragment['costs'] = {
+        __typename: 'SystemIntakeCosts',
+        isExpectingIncrease: 'YES',
+        expectedIncreaseAmount: 'less than $1 million'
       };
 
-    render(
-      <SystemIntakeAnnualCosts
-        annualSpending={legacyAnnualSpending}
-        costs={null}
-      />
-    );
+      render(<SystemIntakeAnnualCosts annualSpending={null} costs={costs} />);
 
-    expect(screen.getByText('Kind of a lot')).toBeInTheDocument();
-    expect(screen.getByText('A big percentage')).toBeInTheDocument();
-    expect(screen.getByText('Less than a million')).toBeInTheDocument();
-    expect(screen.getByText('A small percentage')).toBeInTheDocument();
+      expect(screen.getByText('less than $1 million')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.test.tsx
+++ b/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SystemIntakeFragmentFragment } from 'gql/generated/graphql';
+
+import SystemIntakeAnnualCosts from './SystemIntakeAnnualCosts';
+
+describe('SystemIntakeAnnualCosts', () => {
+  describe('SystemIntakeAnnualCosts component', () => {
+    it('renders the formatted annual spending data', () => {
+      const annualSpending: SystemIntakeFragmentFragment['annualSpending'] = {
+        __typename: 'SystemIntakeAnnualSpending',
+        currentAnnualSpending: '1000',
+        currentAnnualSpendingITPortion: '50',
+        plannedYearOneSpending: '2000',
+        plannedYearOneSpendingITPortion: '60'
+      };
+
+      render(
+        <SystemIntakeAnnualCosts annualSpending={annualSpending} costs={null} />
+      );
+
+      expect(screen.getByText('$1000')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+      expect(screen.getByText('$2000')).toBeInTheDocument();
+      expect(screen.getByText('60%')).toBeInTheDocument();
+    });
+
+    it('renders annual spending data when not a number (legacy data)');
+    const legacyAnnualSpending: SystemIntakeFragmentFragment['annualSpending'] =
+      {
+        __typename: 'SystemIntakeAnnualSpending',
+        currentAnnualSpending: 'Kind of a lot',
+        currentAnnualSpendingITPortion: 'A big percentage',
+        plannedYearOneSpending: 'Less than a million',
+        plannedYearOneSpendingITPortion: 'A small percentage'
+      };
+
+    render(
+      <SystemIntakeAnnualCosts
+        annualSpending={legacyAnnualSpending}
+        costs={null}
+      />
+    );
+
+    expect(screen.getByText('Kind of a lot')).toBeInTheDocument();
+    expect(screen.getByText('A big percentage')).toBeInTheDocument();
+    expect(screen.getByText('Less than a million')).toBeInTheDocument();
+    expect(screen.getByText('A small percentage')).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.tsx
+++ b/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.tsx
@@ -8,6 +8,7 @@ import {
 } from 'components/DescriptionGroup';
 import ReviewRow from 'components/ReviewRow';
 import { yesNoMap } from 'data/common';
+import formatDollars from 'utils/formatDollars';
 import { showSystemVal } from 'utils/showVal';
 
 type SystemIntakeAnnualSpendingProps = {
@@ -33,12 +34,15 @@ const SystemIntakeAnnualSpending = ({
     plannedYearOneSpendingITPortion
   } = annualSpending || {};
 
-  const formatDollars = (value: string | null | undefined) =>
+  const formatDollarsString = (value: string | null | undefined) =>
     showSystemVal(value, {
-      format: val => (Number.isNaN(Number(val)) ? val : `$${val}`)
+      format: val => {
+        const num = Number(val);
+        return Number.isNaN(num) ? val : formatDollars(num);
+      }
     });
 
-  const formatPercentage = (value: string | null | undefined) =>
+  const formatPercentageString = (value: string | null | undefined) =>
     showSystemVal(value, {
       format: val => (Number.isNaN(Number(val)) ? val : `${val}%`)
     });
@@ -50,7 +54,7 @@ const SystemIntakeAnnualSpending = ({
           <div>
             <DescriptionTerm term={t('review.currentAnnualSpending')} />
             <DescriptionDefinition
-              definition={formatDollars(currentAnnualSpending)}
+              definition={formatDollarsString(currentAnnualSpending)}
             />
           </div>
           <div>
@@ -58,7 +62,9 @@ const SystemIntakeAnnualSpending = ({
               term={t('review.currentAnnualSpendingITPortion')}
             />
             <DescriptionDefinition
-              definition={formatPercentage(currentAnnualSpendingITPortion)}
+              definition={formatPercentageString(
+                currentAnnualSpendingITPortion
+              )}
             />
           </div>
         </ReviewRow>
@@ -66,7 +72,7 @@ const SystemIntakeAnnualSpending = ({
           <div>
             <DescriptionTerm term={t('review.plannedYearOneSpending')} />
             <DescriptionDefinition
-              definition={formatDollars(plannedYearOneSpending)}
+              definition={formatDollarsString(plannedYearOneSpending)}
             />
           </div>
           <div>
@@ -74,7 +80,9 @@ const SystemIntakeAnnualSpending = ({
               term={t('review.plannedYearOneSpendingITPortion')}
             />
             <DescriptionDefinition
-              definition={formatPercentage(plannedYearOneSpendingITPortion)}
+              definition={formatPercentageString(
+                plannedYearOneSpendingITPortion
+              )}
             />
           </div>
         </ReviewRow>
@@ -90,13 +98,13 @@ const SystemIntakeAnnualSpending = ({
           <div>
             <DescriptionTerm term={t('review.currentAnnualSpending')} />
             <DescriptionDefinition
-              definition={formatDollars(currentAnnualSpending)}
+              definition={formatDollarsString(currentAnnualSpending)}
             />
           </div>
           <div>
             <DescriptionTerm term={t('review.plannedYearOneSpending')} />
             <DescriptionDefinition
-              definition={formatDollars(plannedYearOneSpending)}
+              definition={formatDollarsString(plannedYearOneSpending)}
             />
           </div>
         </ReviewRow>
@@ -121,7 +129,7 @@ const SystemIntakeAnnualSpending = ({
           <div>
             <DescriptionTerm term={t('review.increase')} />
             <DescriptionDefinition
-              definition={formatDollars(costs.expectedIncreaseAmount)}
+              definition={formatDollarsString(costs.expectedIncreaseAmount)}
             />
           </div>
         )}

--- a/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.tsx
+++ b/src/components/SystemIntakeReview/SystemIntakeAnnualCosts.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SystemIntakeFragmentFragment } from 'gql/generated/graphql';
+
+import {
+  DescriptionDefinition,
+  DescriptionTerm
+} from 'components/DescriptionGroup';
+import ReviewRow from 'components/ReviewRow';
+import { yesNoMap } from 'data/common';
+import { showSystemVal } from 'utils/showVal';
+
+type SystemIntakeAnnualSpendingProps = {
+  annualSpending: SystemIntakeFragmentFragment['annualSpending'];
+  costs: SystemIntakeFragmentFragment['costs'];
+};
+
+/* Conditionally render cost and annual spending information depending on what info is present.
+    Original: Display only "costs" info
+    Intermediate: Display annual spending info
+    Current: Display annual spending and IT portion info
+*/
+const SystemIntakeAnnualSpending = ({
+  annualSpending,
+  costs
+}: SystemIntakeAnnualSpendingProps) => {
+  const { t } = useTranslation('intake');
+
+  const {
+    currentAnnualSpending,
+    currentAnnualSpendingITPortion,
+    plannedYearOneSpending,
+    plannedYearOneSpendingITPortion
+  } = annualSpending || {};
+
+  const formatDollars = (value: string | null | undefined) =>
+    showSystemVal(value, {
+      format: val => (Number.isNaN(Number(val)) ? val : `$${val}`)
+    });
+
+  const formatPercentage = (value: string | null | undefined) =>
+    showSystemVal(value, {
+      format: val => (Number.isNaN(Number(val)) ? val : `${val}%`)
+    });
+
+  if (currentAnnualSpendingITPortion) {
+    return (
+      <>
+        <ReviewRow>
+          <div>
+            <DescriptionTerm term={t('review.currentAnnualSpending')} />
+            <DescriptionDefinition
+              definition={formatDollars(currentAnnualSpending)}
+            />
+          </div>
+          <div>
+            <DescriptionTerm
+              term={t('review.currentAnnualSpendingITPortion')}
+            />
+            <DescriptionDefinition
+              definition={formatPercentage(currentAnnualSpendingITPortion)}
+            />
+          </div>
+        </ReviewRow>
+        <ReviewRow>
+          <div>
+            <DescriptionTerm term={t('review.plannedYearOneSpending')} />
+            <DescriptionDefinition
+              definition={formatDollars(plannedYearOneSpending)}
+            />
+          </div>
+          <div>
+            <DescriptionTerm
+              term={t('review.plannedYearOneSpendingITPortion')}
+            />
+            <DescriptionDefinition
+              definition={formatPercentage(plannedYearOneSpendingITPortion)}
+            />
+          </div>
+        </ReviewRow>
+      </>
+    );
+  }
+
+  // If IT portion field is NOT present but annual spending is - display only annual spending info
+  if (currentAnnualSpending) {
+    return (
+      <>
+        <ReviewRow>
+          <div>
+            <DescriptionTerm term={t('review.currentAnnualSpending')} />
+            <DescriptionDefinition
+              definition={formatDollars(currentAnnualSpending)}
+            />
+          </div>
+          <div>
+            <DescriptionTerm term={t('review.plannedYearOneSpending')} />
+            <DescriptionDefinition
+              definition={formatDollars(plannedYearOneSpending)}
+            />
+          </div>
+        </ReviewRow>
+      </>
+    );
+  }
+
+  // If IT portion AND annual spending fields are not present - it is an old intake so display legacy cost info
+  // TODO: add logic for checking that costs isnt empty here to be safe? diplay error message?
+  return (
+    <>
+      <ReviewRow>
+        <div>
+          <DescriptionTerm term={t('review.costs')} />
+          <DescriptionDefinition
+            definition={
+              costs?.isExpectingIncrease && yesNoMap[costs.isExpectingIncrease]
+            }
+          />
+        </div>
+        {costs?.isExpectingIncrease === 'YES' && (
+          <div>
+            <DescriptionTerm term={t('review.increase')} />
+            <DescriptionDefinition
+              definition={formatDollars(costs.expectedIncreaseAmount)}
+            />
+          </div>
+        )}
+      </ReviewRow>
+    </>
+  );
+};
+
+export default SystemIntakeAnnualSpending;

--- a/src/components/SystemIntakeReview/index.tsx
+++ b/src/components/SystemIntakeReview/index.tsx
@@ -19,9 +19,9 @@ import useSystemIntakeContacts from 'hooks/useSystemIntakeContacts';
 import convertBoolToYesNo from 'utils/convertBoolToYesNo';
 import { formatContractDate, formatDateLocal } from 'utils/date';
 import formatContractNumbers from 'utils/formatContractNumbers';
-import formatNumber from 'utils/formatNumber';
-import { showSystemVal } from 'utils/showVal';
 import { translateRequestType } from 'utils/systemIntake';
+
+import SystemIntakeAnnualSpending from './SystemIntakeAnnualCosts';
 
 import './index.scss';
 
@@ -97,107 +97,6 @@ export const SystemIntakeReview = ({
             </div>
           </ReviewRow>
         )}
-      </>
-    );
-  };
-
-  /* Conditionally render cost and annual spending information depending on what info is present.
-      Original: Display only "costs" info
-      Intermediate: Display annual spending info
-      Current: Display annual spending and IT portion info
-  */
-  const formatCostAndSpendingInfo = () => {
-    // If IT portion field is present, display annual spending and IT portion info
-    if (annualSpending?.currentAnnualSpendingITPortion) {
-      return (
-        <>
-          <ReviewRow>
-            <div>
-              <DescriptionTerm term={t('review.currentAnnualSpending')} />
-              <DescriptionDefinition
-                definition={`$${showSystemVal(
-                  annualSpending.currentAnnualSpending,
-                  { format: formatNumber }
-                )}`}
-              />
-            </div>
-            <div>
-              <DescriptionTerm
-                term={t('review.currentAnnualSpendingITPortion')}
-              />
-              <DescriptionDefinition
-                definition={`${annualSpending.currentAnnualSpendingITPortion}%`}
-              />
-            </div>
-          </ReviewRow>
-          <ReviewRow>
-            <div>
-              <DescriptionTerm term={t('review.plannedYearOneSpending')} />
-              <DescriptionDefinition
-                definition={`$${showSystemVal(
-                  annualSpending.plannedYearOneSpending,
-                  { format: formatNumber }
-                )}`}
-              />
-            </div>
-            <div>
-              <DescriptionTerm
-                term={t('review.plannedYearOneSpendingITPortion')}
-              />
-              <DescriptionDefinition
-                definition={`${annualSpending.plannedYearOneSpendingITPortion}%`}
-              />
-            </div>
-          </ReviewRow>
-        </>
-      );
-    }
-
-    // If IT portion field is NOT present but annual spending is - display only annual spending info
-    if (annualSpending?.currentAnnualSpending) {
-      return (
-        <>
-          <ReviewRow>
-            <div>
-              <DescriptionTerm term={t('review.currentAnnualSpending')} />
-              <DescriptionDefinition
-                definition={annualSpending.currentAnnualSpending}
-              />
-            </div>
-            <div>
-              <DescriptionTerm term={t('review.plannedYearOneSpending')} />
-              <DescriptionDefinition
-                definition={annualSpending.plannedYearOneSpending}
-              />
-            </div>
-          </ReviewRow>
-        </>
-      );
-    }
-
-    // If IT portion AND annual spending fields are not present - it is an old intake so display legacy cost info
-    // TODO: add logic for checking that costs isnt empty here to be safe? diplay error message?
-    return (
-      <>
-        <ReviewRow>
-          <div>
-            <DescriptionTerm term={t('review.costs')} />
-            <DescriptionDefinition
-              definition={
-                systemIntake.costs?.isExpectingIncrease &&
-                yesNoMap[systemIntake.costs.isExpectingIncrease]
-              }
-            />
-          </div>
-          {costs?.isExpectingIncrease === 'YES' && (
-            <div>
-              <DescriptionTerm term={t('review.increase')} />
-              <DescriptionDefinition
-                definition={costs.expectedIncreaseAmount}
-              />
-            </div>
-          )}
-        </ReviewRow>
       </>
     );
   };
@@ -389,8 +288,12 @@ export const SystemIntakeReview = ({
             />
           </div>
         </ReviewRow>
-        {/* Conditionally render annual spending (current) or cost (legacy) questions and answers */}
-        {formatCostAndSpendingInfo()}
+
+        <SystemIntakeAnnualSpending
+          annualSpending={annualSpending}
+          costs={costs}
+        />
+
         <ReviewRow>
           <div>
             <DescriptionTerm term={t('review.contract')} />

--- a/src/features/ITGovernance/Admin/IntakeReview/index.test.tsx
+++ b/src/features/ITGovernance/Admin/IntakeReview/index.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, screen } from '@testing-library/react';
-import { SystemIntakeFragmentFragment } from 'gql/generated/graphql';
 import {
   getSystemIntakeContactsQuery,
   getSystemIntakeQuery,
@@ -11,7 +10,6 @@ import {
 } from 'tests/mock/systemIntake';
 
 import { MessageProvider } from 'hooks/useMessage';
-import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
 import IntakeReview from './index';
 
@@ -63,68 +61,5 @@ describe('The GRT intake review view', () => {
     ).toBeInTheDocument();
 
     expect(asFragment()).toMatchSnapshot();
-  });
-
-  it('renders increased costs data', () => {
-    const costs: SystemIntakeFragmentFragment['costs'] = {
-      __typename: 'SystemIntakeCosts',
-      isExpectingIncrease: 'YES',
-      expectedIncreaseAmount: 'less than $1 million'
-    };
-
-    render(
-      <MemoryRouter>
-        <VerboseMockedProvider
-          mocks={[
-            getSystemIntakeQuery({ costs }),
-            getSystemIntakeContactsQuery
-          ]}
-        >
-          <MessageProvider>
-            <IntakeReview
-              systemIntake={{
-                ...systemIntake,
-                costs
-              }}
-            />
-          </MessageProvider>
-        </VerboseMockedProvider>
-      </MemoryRouter>
-    );
-
-    expect(screen.getByText(/less than \$1 million/i)).toBeInTheDocument();
-  });
-
-  it('renders annual spending data', () => {
-    const annualSpending: SystemIntakeFragmentFragment['annualSpending'] = {
-      __typename: 'SystemIntakeAnnualSpending',
-      currentAnnualSpending: '3.50',
-      currentAnnualSpendingITPortion: '35',
-      plannedYearOneSpending: '123456',
-      plannedYearOneSpendingITPortion: '50'
-    };
-
-    render(
-      <MemoryRouter>
-        <MockedProvider
-          mocks={[
-            getSystemIntakeQuery({ annualSpending }),
-            getSystemIntakeContactsQuery
-          ]}
-        >
-          <MessageProvider>
-            <IntakeReview
-              systemIntake={{
-                ...systemIntake,
-                annualSpending
-              }}
-            />
-          </MessageProvider>
-        </MockedProvider>
-      </MemoryRouter>
-    );
-
-    expect(screen.getByText('$3.5')).toBeInTheDocument();
-    expect(screen.getByText('$123,456')).toBeInTheDocument();
   });
 });

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -114,7 +114,7 @@ const SystemIntakeValidationSchema = {
           'Please enter a valid number for the current annual spending'
         )
         .required('Tell us what the current annual spending for the contract')
-        .positive('Annual spending must be a positive number'),
+        .min(0, 'Annual spending cannot be a negative number'),
       currentAnnualSpendingITPortion: Yup.number()
         .typeError('Please enter a valid number')
         .required(
@@ -127,7 +127,7 @@ const SystemIntakeValidationSchema = {
         .required(
           'Tell us the planned annual spending of the first year of the new contract?'
         )
-        .positive('Annual spending must be a positive number'),
+        .min(0, 'Annual spending cannot be a negative number'),
       plannedYearOneSpendingITPortion: Yup.number()
         .typeError('Please enter a valid number')
         .required('Please enter a valid number for the planned annual spending')


### PR DESCRIPTION
# EASI-4966

## Description
- Updated form validation to allow zero in "What is the current spending" and "What is the planned annual spending" intake fields
- Updated formatting to render values as plain text if not a number
  - Created `SystemIntakeAnnualCosts` component and moved costs logic there
- Unit tests for rendering costs data


## How to test this change
1.  Create new system intake
2. Entering zero should not show error for "What is the current annual spending" and "What is the planned annual spending" fields
3. Go to `/it-governance/a2fa0d4b-909f-45d8-ad8c-90f22cf0db19/intake-request` to view seeded intake with legacy data
4. Annual spending fields should render correctly
<img width="863" height="176" alt="Screenshot 2025-09-18 at 4 45 41 PM" src="https://github.com/user-attachments/assets/ecdd6457-aad4-44f8-ac46-bd5ce06e1506" />


## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [BRUNO Collection](query_examples/EASi) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
