### PR TITLE
[NOREF] Contract dates e2e fix

### DIFF
--- a/src/components/MentionTextArea/__snapshots__/index.test.tsx.snap
+++ b/src/components/MentionTextArea/__snapshots__/index.test.tsx.snap
@@ -39,6 +39,11 @@ exports[`MentionTextArea component > renders the editable text area component 1`
       translate="no"
     >
       <p>
+        <br
+          class="ProseMirror-trailingBreak"
+        />
+      </p>
+      <p>
         This is the text!
       </p>
     </div>

--- a/src/components/MentionTextArea/__snapshots__/index.test.tsx.snap
+++ b/src/components/MentionTextArea/__snapshots__/index.test.tsx.snap
@@ -39,11 +39,6 @@ exports[`MentionTextArea component > renders the editable text area component 1`
       translate="no"
     >
       <p>
-        <br
-          class="ProseMirror-trailingBreak"
-        />
-      </p>
-      <p>
         This is the text!
       </p>
     </div>

--- a/src/features/ITGovernance/Admin/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/features/ITGovernance/Admin/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -458,7 +458,7 @@ exports[`The GRT intake review view > matches the snapshot 1`] = `
                 <dd
                   class="description-definition margin-0"
                 >
-                  1/2020 to 12/2020
+                  01/10/2020 to 12/10/2020
                 </dd>
               </div>
             </div>

--- a/src/tests/mock/systemIntake.ts
+++ b/src/tests/mock/systemIntake.ts
@@ -420,13 +420,13 @@ export const systemIntake: SystemIntakeFragmentFragment = {
     startDate: {
       __typename: 'ContractDate',
       month: '1',
-      day: '',
+      day: '10',
       year: '2020'
     },
     endDate: {
       __typename: 'ContractDate',
       month: '12',
-      day: '',
+      day: '10',
       year: '2020'
     }
   },

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -61,17 +61,17 @@ describe('formatDateLocal/UTC', () => {
         year: '2022'
       };
 
-      expect(formatContractDate(input)).toEqual('2/1/2022');
+      expect(formatContractDate(input)).toEqual('02/01/2022');
     });
 
-    it('formats a date without a day', () => {
+    it('returns an empty string when the date is incomplete', () => {
       const input = {
         day: '',
         month: '2',
         year: '2022'
       };
 
-      expect(formatContractDate(input)).toEqual('2/2022');
+      expect(formatContractDate(input)).toEqual('');
     });
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,4 @@
+import { ContractDate } from 'gql/generated/graphql';
 import { DateTime, Interval } from 'luxon';
 
 // Used to parse out mintute, day, ,month, and years from ISOString
@@ -110,22 +111,20 @@ export const formatEndOfDayDeadline = (date: DateTime | string): string => {
   return formattedDateTime.toISO({ suppressMilliseconds: true });
 };
 
-type ContractDate = {
-  day?: string | null | undefined;
-  month?: string | null | undefined;
-  year?: string | null | undefined;
-};
+/** Formats contract date object into MM/dd/yyyy format */
+export function formatContractDate({
+  month,
+  day,
+  year
+}: Omit<ContractDate, '__typename'>) {
+  if (!month || !day || !year) return '';
 
-export const formatContractDate = (date?: ContractDate): string => {
-  if (!date) return '';
+  // Pad month and day with leading zeros if needed
+  const formattedMonth = month.padStart(2, '0');
+  const formattedDay = day.padStart(2, '0');
 
-  const { month, day, year } = date;
-
-  const parts = [month, day, year];
-  return parts
-    .filter((value: string | null | undefined) => value && value.length > 0)
-    .join('/');
-};
+  return `${formattedMonth}/${formattedDay}/${year}`;
+}
 
 /**
  * Returns the input parameter's fiscal year


### PR DESCRIPTION
# NOREF

## Description
- Fixes e2e test failure affecting all PRs (example here) caused by contract date formatting
  - Test is looking for `11/01/2025` but date was displayed `11/1/2025`
- Updated `formatContractDate` to return date formatted as `MM/dd/yyyy` to match other date instances
- Updated unit tests


## How to test this change
1.  e2e and unit tests should pass 

## PR Author Checklist

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [BRUNO Collection](query_examples/EASi) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
